### PR TITLE
`tib_vector()` replaces empty fields by `NULL`

### DIFF
--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -344,7 +344,7 @@ public:
   inline void add_value(SEXP value, Path& path) {
     // TODO use `NULL` if `value` is empty?
     if (!Rf_isNull(this->transform)) value = apply_transform(value, this->transform);
-    SEXP value_casted = vec_cast(value, ptype);
+    SEXP value_casted = (Rf_length(value) == 0) ? R_NilValue : vec_cast(value, ptype);
     SET_VECTOR_ELT(this->data, this->current_row++, value_casted);
   }
 

--- a/tests/testthat/test-tibblify.R
+++ b/tests/testthat/test-tibblify.R
@@ -123,6 +123,19 @@ test_that("vector column works", {
   expect_equal(tib(list(x = c(TRUE, FALSE)), tib_lgl_vec("x")), tibble(x = list_of(c(TRUE, FALSE))))
   expect_equal(tib(list(x = c(dtt, dtt + 1)), tib_vector("x", dtt)), tibble(x = list_of(c(dtt, dtt + 1))))
 
+  # can handle empty element
+  expect_equal(
+    tibblify(
+      list(
+        list(x = c(TRUE, FALSE)),
+        list(x = NULL),
+        list(x = list())
+      ),
+      spec_df(x = tib_lgl_vec("x"))
+    ),
+    tibble(x = list_of(c(TRUE, FALSE), NULL, NULL))
+  )
+
   # errors if required but absent
   expect_snapshot_error(tib(list(), tib_lgl_vec("x")))
   expect_snapshot_error(tib(list(), tib_vector("x", dtt)))


### PR DESCRIPTION
Closes #41.

* use `vec_size()` instead of `Rf_length()`?
* or should this be more strict and only work for lists?