### PR TITLE
WIP: trigger protection errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,5 @@ NeedsCompilation: yes
 Config/testthat/edition: 3
 LinkingTo: 
     cpp11,
-    plogr,
     vctrs (>= 0.3.6)
 SystemRequirements: C++11

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,5 +40,6 @@ NeedsCompilation: yes
 Config/testthat/edition: 3
 LinkingTo: 
     cpp11,
+    plogr,
     vctrs (>= 0.3.6)
 SystemRequirements: C++11

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,8 @@
 path_to_string <- function(path) {
+  if (length(path) == 0) {
+    return("<root>")
+  }
+
   path_elements <- purrr::map_chr(
     path,
     function(elt) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -29,6 +29,30 @@ stop_scalar <- function(path) {
   abort(message)
 }
 
+stop_duplicate_name <- function(path) {
+  path_str <- path_to_string(path)
+  message <- c(
+    paste0("Element at path ", path_str, " has duplicate name.")
+  )
+  abort(message)
+}
+
+stop_empty_name <- function(path) {
+  path_str <- path_to_string(path)
+  message <- c(
+    paste0("Element at path ", path_str, " has empty name.")
+  )
+  abort(message)
+}
+
+stop_names_is_null <- function(path) {
+  path_str <- path_to_string(path)
+  message <- c(
+    paste0("Element at path ", path_str, " has NULL names.")
+  )
+  abort(message)
+}
+
 vec_flatten <- function(x, ptype) {
   vctrs::vec_unchop(x, ptype = ptype)
 }

--- a/src/Path.h
+++ b/src/Path.h
@@ -3,19 +3,20 @@
 
 class Path {
 private:
-  SEXP path = PROTECT(Rf_allocVector(VECSXP, 20));
+  cpp11::writable::list path;
   int depth = 0;
   Path(const Path&);
   Path& operator=(const Path&);
 
 public:
-  Path() {}
-
-  ~ Path() {
-    UNPROTECT(1);
+  Path() {
+    path = Rf_allocVector(VECSXP, 20);
   }
 
+  ~ Path() {}
+
   inline void down() {
+    // FIXME: fail if diving too deep
     this->depth++;
   }
 

--- a/src/Path.h
+++ b/src/Path.h
@@ -25,11 +25,11 @@ public:
   }
 
   inline void replace(int index) {
-    // SET_VECTOR_ELT(this->path, this->depth, Rf_ScalarInteger(index));
+    SET_VECTOR_ELT(this->path, this->depth, Rf_ScalarInteger(index));
   }
 
-  inline void replace(const SEXP key) {
-    // SET_VECTOR_ELT(this->path, this->depth, key);
+  inline void replace(const SEXP* key) {
+    SET_VECTOR_ELT(this->path, this->depth, *key);
   }
 
   inline SEXP data() const {

--- a/src/Path.h
+++ b/src/Path.h
@@ -25,11 +25,11 @@ public:
   }
 
   inline void replace(int index) {
-    SET_VECTOR_ELT(this->path, this->depth, Rf_ScalarInteger(index));
+    // SET_VECTOR_ELT(this->path, this->depth, Rf_ScalarInteger(index));
   }
 
-  inline void replace(const SEXP* key) {
-    SET_VECTOR_ELT(this->path, this->depth, *key);
+  inline void replace(const SEXP key) {
+    // SET_VECTOR_ELT(this->path, this->depth, key);
   }
 
   inline SEXP data() const {

--- a/src/Path.h
+++ b/src/Path.h
@@ -28,8 +28,8 @@ public:
     SET_VECTOR_ELT(this->path, this->depth, Rf_ScalarInteger(index));
   }
 
-  inline void replace(const SEXP* key) {
-    SET_VECTOR_ELT(this->path, this->depth, *key);
+  inline void replace(const SEXP key) {
+    SET_VECTOR_ELT(this->path, this->depth, key);
   }
 
   inline SEXP data() const {

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -180,8 +180,7 @@ private:
   const SEXP ptype = tibblify_shared_empty_lgl;
   int* data_ptr;
 private:
-  SEXP data;
-  bool needs_unprotect = false;
+  cpp11::writable::logicals data;
 
 public:
   Collector_Scalar_Lgl(int default_value_, bool required_, int col_location_,
@@ -191,9 +190,8 @@ public:
   { }
 
   inline void init(R_xlen_t& length) {
-    this->data = PROTECT(Rf_allocVector(LGLSXP, length));
+    this->data = Rf_allocVector(LGLSXP, length);
     this->data_ptr = LOGICAL(this->data);
-    this->needs_unprotect = true;
   }
 
   inline void add_value(SEXP value, Path& path) {
@@ -220,8 +218,7 @@ private:
   const SEXP ptype = tibblify_shared_empty_int;
   int* data_ptr;
 private:
-  SEXP data;
-  bool needs_unprotect = false;
+  cpp11::writable::integers data;
 
 public:
   Collector_Scalar_Int(int default_value_, bool required_, int col_location_,
@@ -231,9 +228,8 @@ public:
   { }
 
   inline void init(R_xlen_t& length) {
-    this->data = PROTECT(Rf_allocVector(INTSXP, length));
+    this->data = Rf_allocVector(INTSXP, length);
     this->data_ptr = INTEGER(this->data);
-    this->needs_unprotect = true;
   }
 
   inline void add_value(SEXP value, Path& path) {
@@ -260,8 +256,7 @@ private:
   const SEXP ptype = tibblify_shared_empty_dbl;
   double* data_ptr;
 private:
-  SEXP data;
-  bool needs_unprotect = false;
+  cpp11::writable::doubles data;
 
 public:
   Collector_Scalar_Dbl(double default_value_, bool required_, int col_location_,
@@ -271,9 +266,8 @@ public:
   { }
 
   inline void init(R_xlen_t& length) {
-    this->data = PROTECT(Rf_allocVector(REALSXP, length));
+    this->data = Rf_allocVector(REALSXP, length);
     this->data_ptr = REAL(this->data);
-    this->needs_unprotect = true;
   }
 
   inline void add_value(SEXP value, Path& path) {
@@ -300,8 +294,7 @@ private:
   const SEXP ptype = tibblify_shared_empty_chr;
   SEXP* data_ptr;
 private:
-  SEXP data;
-  bool needs_unprotect = false;
+  cpp11::writable::strings data;
 
 public:
   Collector_Scalar_Str(SEXP default_value_, bool required_, int col_location_,
@@ -311,9 +304,8 @@ public:
   { }
 
   void init(R_xlen_t& length) {
-    this->data = PROTECT(Rf_allocVector(STRSXP, length));
+    this->data = Rf_allocVector(STRSXP, length);
     this->data_ptr = STRING_PTR(this->data);
-    this->needs_unprotect = true;
   }
 
   void add_value(SEXP value, Path& path) {
@@ -341,8 +333,7 @@ protected:
   const SEXP ptype;
   int current_row = 0;
 private:
-  SEXP data;
-  bool needs_unprotect = false;
+  cpp11::writable::list data;
 
 public:
   Collector_Vector(SEXP default_value_, bool required_, SEXP ptype_, int col_location_,
@@ -353,9 +344,8 @@ public:
   { }
 
   inline void init(R_xlen_t& length) {
-    this->data = PROTECT(init_list_of(length, this->ptype));
+    this->data = init_list_of(length, this->ptype);
     this->current_row = 0;
-    this->needs_unprotect = true;
   }
 
   inline void add_value(SEXP value, Path& path) {
@@ -392,8 +382,7 @@ protected:
   const SEXP default_value;
   int current_row = 0;
 private:
-  SEXP data;
-  bool needs_unprotect = false;
+  cpp11::writable::list data;
 
 public:
   Collector_List(SEXP default_value_, bool required_, int col_location_, SEXP name_,
@@ -403,9 +392,8 @@ public:
   { }
 
   inline void init(R_xlen_t& length) {
-    this->data = PROTECT(Rf_allocVector(VECSXP, length));
+    this->data = Rf_allocVector(VECSXP, length);
     this->current_row = 0;
-    this->needs_unprotect = true;
   }
 
   inline void add_value(SEXP value, Path& path) {

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -76,7 +76,6 @@ using Collector_Ptr = std::unique_ptr<Collector>;
 
 class Collector_Scalar_Base : public Collector {
 protected:
-  SEXP data;
   const bool required;
   const int col_location;
   const SEXP name;
@@ -101,6 +100,7 @@ protected:
   const SEXP ptype;
   int current_row = 0;
 private:
+  SEXP data;
   bool needs_unprotect = false;
 
 public:
@@ -182,6 +182,7 @@ private:
   const SEXP ptype = tibblify_shared_empty_lgl;
   int* data_ptr;
 private:
+  SEXP data;
   bool needs_unprotect = false;
 
 public:
@@ -221,6 +222,7 @@ private:
   const SEXP ptype = tibblify_shared_empty_int;
   int* data_ptr;
 private:
+  SEXP data;
   bool needs_unprotect = false;
 
 public:
@@ -260,6 +262,7 @@ private:
   const SEXP ptype = tibblify_shared_empty_dbl;
   double* data_ptr;
 private:
+  SEXP data;
   bool needs_unprotect = false;
 
 public:
@@ -299,6 +302,7 @@ private:
   const SEXP ptype = tibblify_shared_empty_chr;
   SEXP* data_ptr;
 private:
+  SEXP data;
   bool needs_unprotect = false;
 
 public:
@@ -339,6 +343,7 @@ protected:
   const SEXP ptype;
   int current_row = 0;
 private:
+  SEXP data;
   bool needs_unprotect = false;
 
 public:
@@ -389,6 +394,7 @@ protected:
   const SEXP default_value;
   int current_row = 0;
 private:
+  SEXP data;
   bool needs_unprotect = false;
 
 public:

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -498,7 +498,7 @@ public:
     if (n_fields == 0) {
       path.down();
       for (int key_index = 0; key_index < this->n_keys; key_index++, key_names_ptr++) {
-        path.replace(key_names_ptr);
+        path.replace(*key_names_ptr);
         (*this->collector_vec[key_index]).add_default(path);
       }
       path.up();
@@ -527,7 +527,7 @@ public:
       SEXPREC* field_nm = field_names_ptr[this->ind[field_index]];
 
       if (field_nm == *key_names_ptr) {
-        path.replace(key_names_ptr);
+        path.replace(*key_names_ptr);
         (*this->collector_vec[key_index]).add_value(values_ptr[this->ind[field_index]], path);
         key_names_ptr++; key_index++;
         field_index++;
@@ -537,7 +537,7 @@ public:
       const char* key_char = CHAR(*key_names_ptr); // TODO might be worth caching
       const char* field_nm_char = CHAR(field_nm);
       if (strcmp(key_char, field_nm_char) < 0) {
-        path.replace(key_names_ptr);
+        path.replace(*key_names_ptr);
         (*this->collector_vec[key_index]).add_default(path);
         key_names_ptr++; key_index++;
         continue;
@@ -549,7 +549,7 @@ public:
     }
 
     for (; key_index < this->n_keys; key_index++) {
-      path.replace(key_names_ptr);
+      path.replace(*key_names_ptr);
       (*this->collector_vec[key_index]).add_default(path);
       key_names_ptr++;
     }

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -481,13 +481,6 @@ public:
     }
   }
 
-  inline void unprotect() {
-    if (this->needs_unprotect) {
-      UNPROTECT(1);
-      this->needs_unprotect = false;
-    }
-  }
-
   inline void init(R_xlen_t& length) {
     for (const Collector_Ptr& collector : this->collector_vec) {
       (*collector).init(length);
@@ -572,10 +565,6 @@ public:
   , n_keys(Rf_length(keys_))
   { }
 
-  inline void unprotect() {
-    Multi_Collector::unprotect();
-  }
-
   inline int size() const {
     int size = 0;
     for (const Collector_Ptr& collector : this->collector_vec) {
@@ -650,10 +639,6 @@ public:
 
   ~ Collector_Tibble() {}
 
-  inline void unprotect() {
-    Multi_Collector::unprotect();
-  }
-
   inline int size() const {
     return 1;
   }
@@ -722,7 +707,6 @@ private:
     set_df_attributes(df, n_rows);
 
     UNPROTECT(2);
-    Multi_Collector::unprotect();
     return df;
   }
 
@@ -783,7 +767,6 @@ private:
     set_df_attributes(df, 1);
 
     UNPROTECT(2);
-    Multi_Collector::unprotect();
     return df;
   }
 
@@ -821,13 +804,6 @@ public:
   , col_location(col_location_)
   , parser_ptr(std::unique_ptr<Parser_Object_List>(new Parser_Object_List(keys_, col_vec_, names_col_)))
   { }
-
-  inline void unprotect() {
-    if (this->needs_unprotect) {
-      UNPROTECT(1);
-      this->needs_unprotect = false;
-    }
-  }
 
   inline void init(R_xlen_t& length) {
     Path path;

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -156,7 +156,7 @@ public:
 
 #define ADD_VALUE(F_SCALAR)                                    \
   if (!Rf_isNull(this->transform)) value = apply_transform(value, this->transform); \
-  SEXP value_casted = vec_cast(PROTECT(value), this->ptype);   \
+  SEXP value_casted = PROTECT(vec_cast(PROTECT(value), this->ptype));   \
   R_len_t size = short_vec_size(value_casted);                 \
   if (size == 0) {                                             \
     *this->data_ptr = this->default_value;                     \
@@ -167,7 +167,7 @@ public:
   }                                                            \
                                                                \
   ++this->data_ptr;                                            \
-  UNPROTECT(1);
+  UNPROTECT(2);
 
 #define ADD_DEFAULT()                                          \
   if (this->required) stop_required(path);                     \
@@ -738,7 +738,8 @@ public:
       for (R_xlen_t row_index = 0; row_index < n_rows; row_index++) {
         path.replace(row_index);
         *slice_index_int_ptr = row_index + 1;
-        this->add_value(vec_slice_impl(object_list, slice_index_int), path);
+        this->add_value(PROTECT(vec_slice_impl(object_list, slice_index_int)), path);
+        UNPROTECT(1);
       }
       UNPROTECT(1);
     }

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -419,7 +419,7 @@ public:
 
 class Multi_Collector {
 private:
-  SEXP field_names_prev = R_NilValue;
+  cpp11::strings field_names_prev;
   int n_fields_prev = 0;
   const int INDEX_SIZE = 256;
   int *ind = (int *) R_alloc(this->INDEX_SIZE, sizeof(int));

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -427,13 +427,13 @@ class Multi_Collector {
 private:
   cpp11::strings field_names_prev;
   int n_fields_prev = 0;
-  const int INDEX_SIZE = 256;
-  int *ind = (int *) R_alloc(this->INDEX_SIZE, sizeof(int));
+  static const int INDEX_SIZE = 256;
+  int ind[INDEX_SIZE];
 
   inline bool have_fields_changed(SEXP field_names, const int& n_fields) const {
     if (n_fields != this->n_fields_prev) return true;
 
-    if (n_fields > this->INDEX_SIZE) cpp11::stop("At most 256 fields are supported");
+    if (n_fields >= INDEX_SIZE) cpp11::stop("At most 256 fields are supported");
     const SEXP* nms_ptr = STRING_PTR_RO(field_names);
     const SEXP* nms_ptr_prev = STRING_PTR_RO(this->field_names_prev);
     for (int i = 0; i < n_fields; i++, nms_ptr++, nms_ptr_prev++)

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -785,14 +785,12 @@ public:
 
 class Collector_List_Of_Tibble : public Collector {
 private:
-  SEXP data;
+  cpp11::writable::list data;
   const bool required;
   const SEXP name;
   const int col_location;
   const std::unique_ptr<Parser_Object_List> parser_ptr;
   int current_row = 0;
-private:
-  bool needs_unprotect = false;
 
 public:
   Collector_List_Of_Tibble(SEXP keys_, std::vector<Collector_Ptr>& col_vec_, SEXP names_col_,
@@ -806,9 +804,8 @@ public:
   inline void init(R_xlen_t& length) {
     Path path;
     SEXP ptype = (*this->parser_ptr).parse(tibblify_shared_empty_list, path);
-    this->data = PROTECT(init_list_of(length, ptype));
+    this->data = init_list_of(length, ptype);
     this->current_row = 0;
-    this->needs_unprotect = true;
   }
 
   inline void add_value(SEXP value, Path& path) {

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -120,7 +120,7 @@ public:
 
   inline void add_value(SEXP value, Path& path) {
     if (!Rf_isNull(this->transform)) value = apply_transform(value, this->transform);
-    SEXP value_casted = vec_cast(value, ptype);
+    SEXP value_casted = vec_cast(PROTECT(value), ptype);
     R_len_t size = short_vec_size(value_casted);
     if (size == 0) {
       value_casted = this->default_value;
@@ -129,6 +129,7 @@ public:
     }
 
     SET_VECTOR_ELT(this->data, this->current_row++, value_casted);
+    UNPROTECT(1);
   }
 
   inline void add_default(Path& path) {
@@ -155,7 +156,7 @@ public:
 
 #define ADD_VALUE(F_SCALAR)                                    \
   if (!Rf_isNull(this->transform)) value = apply_transform(value, this->transform); \
-  SEXP value_casted = vec_cast(value, this->ptype);            \
+  SEXP value_casted = vec_cast(PROTECT(value), this->ptype);   \
   R_len_t size = short_vec_size(value_casted);                 \
   if (size == 0) {                                             \
     *this->data_ptr = this->default_value;                     \
@@ -165,7 +166,8 @@ public:
     stop_scalar(path);                                         \
   }                                                            \
                                                                \
-  ++this->data_ptr;
+  ++this->data_ptr;                                            \
+  UNPROTECT(1);
 
 #define ADD_DEFAULT()                                          \
   if (this->required) stop_required(path);                     \
@@ -360,8 +362,9 @@ public:
       return;
     }
 
-    SEXP value_casted = vec_cast(value, ptype);
+    SEXP value_casted = vec_cast(PROTECT(value), ptype);
     SET_VECTOR_ELT(this->data, this->current_row++, value_casted);
+    UNPROTECT(1);
   }
 
   inline void add_default(Path& path) {

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -100,8 +100,7 @@ protected:
   const SEXP ptype;
   int current_row = 0;
 private:
-  SEXP data;
-  bool needs_unprotect = false;
+  cpp11::writable::list data;
 
 public:
   Collector_Scalar(SEXP default_value_, bool required_, SEXP ptype_, int col_location_,
@@ -112,9 +111,8 @@ public:
   { }
 
   inline void init(R_xlen_t& length) {
-    this->data = PROTECT(Rf_allocVector(VECSXP, length));
+    this->data = Rf_allocVector(VECSXP, length);
     this->current_row = 0;
-    this->needs_unprotect = true;
   }
 
   inline void add_value(SEXP value, Path& path) {

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -11,9 +11,6 @@
 #include "utils.h"
 #include "Path.h"
 
-#define PLOGR_ENABLE
-#include <plogr.h>
-
 inline void stop_scalar(const Path& path) {
   SEXP call = PROTECT(Rf_lang2(Rf_install("stop_scalar"),
                                PROTECT(path.data())));
@@ -122,7 +119,6 @@ public:
   }
 
   inline void add_value(SEXP value, Path& path) {
-    LOG_VERBOSE;
     if (!Rf_isNull(this->transform)) value = apply_transform(value, this->transform);
     SEXP value_casted = vec_cast(PROTECT(value), ptype);
     R_len_t size = short_vec_size(value_casted);
@@ -146,8 +142,6 @@ public:
   }
 
   inline void assign_data(SEXP list, SEXP names) const {
-        LOG_VERBOSE;
-
     SEXP call = PROTECT(Rf_lang3(Rf_install("vec_flatten"),
                                  this->data,
                                  this->ptype));
@@ -162,7 +156,7 @@ public:
 
 #define ADD_VALUE(F_SCALAR)                                    \
   if (!Rf_isNull(this->transform)) value = apply_transform(value, this->transform); \
-  SEXP value_casted = PROTECT(vec_cast(PROTECT(value), this->ptype));   \
+  SEXP value_casted = vec_cast(PROTECT(value), this->ptype);   \
   R_len_t size = short_vec_size(value_casted);                 \
   if (size == 0) {                                             \
     *this->data_ptr = this->default_value;                     \
@@ -173,7 +167,7 @@ public:
   }                                                            \
                                                                \
   ++this->data_ptr;                                            \
-  UNPROTECT(2);
+  UNPROTECT(1);
 
 #define ADD_DEFAULT()                                          \
   if (this->required) stop_required(path);                     \
@@ -206,7 +200,6 @@ public:
   }
 
   inline void add_value(SEXP value, Path& path) {
-    LOG_VERBOSE;
     ADD_VALUE(Rf_asLogical);
   }
 
@@ -219,8 +212,6 @@ public:
   }
 
   inline void assign_data(SEXP list, SEXP names) const {
-        LOG_VERBOSE;
-
     SET_VECTOR_ELT(list, this->col_location, this->data);
     SET_STRING_ELT(names, this->col_location, this->name);
   }
@@ -247,7 +238,6 @@ public:
   }
 
   inline void add_value(SEXP value, Path& path) {
-    LOG_VERBOSE;
     ADD_VALUE(Rf_asInteger);
   }
 
@@ -260,8 +250,6 @@ public:
   }
 
   inline void assign_data(SEXP list, SEXP names) const {
-        LOG_VERBOSE;
-
     SET_VECTOR_ELT(list, this->col_location, this->data);
     SET_STRING_ELT(names, this->col_location, this->name);
   }
@@ -288,7 +276,6 @@ public:
   }
 
   inline void add_value(SEXP value, Path& path) {
-    LOG_VERBOSE;
     ADD_VALUE(Rf_asReal);
   }
 
@@ -301,8 +288,6 @@ public:
   }
 
   inline void assign_data(SEXP list, SEXP names) const {
-        LOG_VERBOSE;
-
     SET_VECTOR_ELT(list, this->col_location, this->data);
     SET_STRING_ELT(names, this->col_location, this->name);
   }
@@ -341,8 +326,6 @@ public:
   }
 
   inline void assign_data(SEXP list, SEXP names) const {
-    LOG_VERBOSE;
-
     SET_VECTOR_ELT(list, this->col_location, this->data);
     SET_STRING_ELT(names, this->col_location, this->name);
   }
@@ -371,7 +354,6 @@ public:
   }
 
   inline void add_value(SEXP value, Path& path) {
-    LOG_VERBOSE;
     // TODO use `NULL` if `value` is empty?
     if (!Rf_isNull(this->transform)) value = apply_transform(value, this->transform);
     // TODO should be controlled via an argument to `tibblify()`
@@ -382,7 +364,6 @@ public:
 
     SEXP value_casted = vec_cast(PROTECT(value), ptype);
     SET_VECTOR_ELT(this->data, this->current_row++, value_casted);
-    LOG_VERBOSE;
     UNPROTECT(1);
   }
 
@@ -396,8 +377,6 @@ public:
   }
 
   inline void assign_data(SEXP list, SEXP names) const {
-        LOG_VERBOSE;
-
     SET_VECTOR_ELT(list, this->col_location, this->data);
     SET_STRING_ELT(names, this->col_location, this->name);
   }
@@ -424,7 +403,6 @@ public:
   }
 
   inline void add_value(SEXP value, Path& path) {
-    LOG_VERBOSE;
     if (!Rf_isNull(this->transform)) value = apply_transform(value, this->transform);
     SET_VECTOR_ELT(this->data, this->current_row++, value);
   }
@@ -439,8 +417,6 @@ public:
   }
 
   inline void assign_data(SEXP list, SEXP names) const {
-    LOG_VERBOSE;
-
     SET_VECTOR_ELT(list, this->col_location, this->data);
     SET_STRING_ELT(names, this->col_location, this->name);
   }
@@ -516,18 +492,13 @@ public:
   }
 
   inline void add_value(SEXP object, Path& path) {
-    //PROTECT(object);
-
-    LOG_VERBOSE << object;
-    LOG_VERBOSE << TYPEOF(object);
-    LOG_VERBOSE << Rf_xlength(object);
     const SEXP* key_names_ptr = STRING_PTR_RO(this->keys);
     const int n_fields = Rf_length(object);
 
     if (n_fields == 0) {
       path.down();
       for (int key_index = 0; key_index < this->n_keys; key_index++, key_names_ptr++) {
-        path.replace(*key_names_ptr);
+        path.replace(key_names_ptr);
         (*this->collector_vec[key_index]).add_default(path);
       }
       path.up();
@@ -545,58 +516,28 @@ public:
       this->check_names(field_names_ptr, n_fields, path);
     }
 
-    for (int i = 0; i < n_fields; ++i) {
-      const SEXP* values_ptr = VECTOR_PTR_RO(object);
-      LOG_VERBOSE << values_ptr[i];
-      LOG_VERBOSE << Rf_xlength(values_ptr[i]);
-    }
+    // TODO VECTOR_PTR_RO only works if object is a list
+    const SEXP* values_ptr = VECTOR_PTR_RO(object);
 
     // The manual loop is quite a bit faster than the range based loop
     path.down();
     int key_index = 0;
     int field_index = 0;
     for (field_index = 0; (field_index < n_fields) && (key_index < this->n_keys); ) {
-      // TODO VECTOR_PTR_RO only works if object is a list
-      const SEXP* values_ptr = VECTOR_PTR_RO(object);
-
-      LOG_VERBOSE;
       SEXPREC* field_nm = field_names_ptr[this->ind[field_index]];
 
       if (field_nm == *key_names_ptr) {
-        LOG_VERBOSE << field_index;
-        LOG_VERBOSE << this->ind[field_index];
-        LOG_VERBOSE << values_ptr[this->ind[field_index]];
-        LOG_VERBOSE << Rf_xlength(values_ptr[this->ind[field_index]]);
-
-        path.replace(*key_names_ptr);
-
-        LOG_VERBOSE << n_fields;
-        LOG_VERBOSE << object;
-        for (int i = 0; i < n_fields; ++i) {
-          const SEXP* values_ptr = VECTOR_PTR_RO(object);
-          LOG_VERBOSE << values_ptr[i];
-          LOG_VERBOSE << Rf_xlength(values_ptr[i]);
-        }
-
+        path.replace(key_names_ptr);
         (*this->collector_vec[key_index]).add_value(values_ptr[this->ind[field_index]], path);
         key_names_ptr++; key_index++;
         field_index++;
-
-        LOG_VERBOSE << n_fields;
-        LOG_VERBOSE << object;
-        for (int i = 0; i < n_fields; ++i) {
-          const SEXP* values_ptr = VECTOR_PTR_RO(object);
-          LOG_VERBOSE << values_ptr[i];
-          LOG_VERBOSE << Rf_xlength(values_ptr[i]);
-        }
-
         continue;
       }
 
       const char* key_char = CHAR(*key_names_ptr); // TODO might be worth caching
       const char* field_nm_char = CHAR(field_nm);
       if (strcmp(key_char, field_nm_char) < 0) {
-        path.replace(*key_names_ptr);
+        path.replace(key_names_ptr);
         (*this->collector_vec[key_index]).add_default(path);
         key_names_ptr++; key_index++;
         continue;
@@ -607,19 +548,13 @@ public:
       field_index++;
     }
 
-    LOG_VERBOSE;
-
     for (; key_index < this->n_keys; key_index++) {
-      LOG_VERBOSE;
-      path.replace(*key_names_ptr);
+      path.replace(key_names_ptr);
       (*this->collector_vec[key_index]).add_default(path);
       key_names_ptr++;
     }
 
     path.up();
-
-    LOG_VERBOSE;
-    //UNPROTECT(1);
   }
 };
 
@@ -648,9 +583,7 @@ public:
   }
 
   inline void add_value(SEXP object, Path& path) {
-    LOG_VERBOSE;
     Multi_Collector::add_value(object, path);
-    LOG_VERBOSE;
   }
 
   inline void add_default(Path& path) {
@@ -720,9 +653,7 @@ public:
   }
 
   inline void add_value(SEXP object, Path& path) {
-    LOG_VERBOSE;
     Multi_Collector::add_value(object, path);
-    LOG_VERBOSE;
   }
 
   inline void add_default(Path& path) {
@@ -761,7 +692,6 @@ private:
   }
 
   inline SEXP get_data(SEXP object_list, R_xlen_t n_rows) {
-    LOG_VERBOSE;
     const int n_cols = this->get_n_cols();
     SEXP df = PROTECT(Rf_allocVector(VECSXP, n_cols));
 
@@ -774,7 +704,6 @@ private:
     }
 
     for (const Collector_Ptr& collector : this->collector_vec) {
-      LOG_VERBOSE;
       (*collector).assign_data(df, names);
     }
 
@@ -782,7 +711,6 @@ private:
     set_df_attributes(df, n_rows);
 
     UNPROTECT(2);
-    LOG_VERBOSE;
     return df;
   }
 
@@ -794,40 +722,28 @@ public:
   { }
 
   inline SEXP parse(SEXP object_list, Path& path) {
-    LOG_VERBOSE << object_list;
-    LOG_VERBOSE << Rf_xlength(object_list);
     R_xlen_t n_rows = short_vec_size(object_list);
-    LOG_VERBOSE;
     this->init(n_rows);
-    LOG_VERBOSE;
 
     if (vec_is_list(object_list)) {
-      LOG_VERBOSE;
       const SEXP* ptr_row = VECTOR_PTR_RO(object_list);
       for (R_xlen_t row_index = 0; row_index < n_rows; row_index++) {
-        LOG_VERBOSE << row_index;
         path.replace(row_index);
         this->add_value(ptr_row[row_index], path);
       }
     } else {
-      LOG_VERBOSE;
       SEXP slice_index_int = PROTECT(Rf_allocVector(INTSXP, 1));
       int* slice_index_int_ptr = INTEGER(slice_index_int);
 
       for (R_xlen_t row_index = 0; row_index < n_rows; row_index++) {
-        LOG_VERBOSE;
         path.replace(row_index);
         *slice_index_int_ptr = row_index + 1;
-        this->add_value(PROTECT(vec_slice_impl(object_list, slice_index_int)), path);
-        UNPROTECT(1);
+        this->add_value(vec_slice_impl(object_list, slice_index_int), path);
       }
       UNPROTECT(1);
     }
 
-    LOG_VERBOSE;
-    SEXP out = this->get_data(object_list, n_rows);
-    LOG_VERBOSE;
-    return out;
+    return this->get_data(object_list, n_rows);
   }
 };
 
@@ -843,7 +759,6 @@ private:
   }
 
   inline SEXP get_data() {
-    LOG_VERBOSE;
     const int n_cols = this->get_n_cols();
     SEXP df = PROTECT(Rf_allocVector(VECSXP, n_cols));
     SEXP names = PROTECT(Rf_allocVector(STRSXP, n_cols));
@@ -894,16 +809,12 @@ public:
 
   inline void init(R_xlen_t& length) {
     Path path;
-
-    LOG_VERBOSE;
     SEXP ptype = (*this->parser_ptr).parse(tibblify_shared_empty_list, path);
     this->data = init_list_of(length, ptype);
     this->current_row = 0;
   }
 
   inline void add_value(SEXP value, Path& path) {
-    LOG_VERBOSE << value;
-    LOG_VERBOSE << Rf_xlength(value);
     SET_VECTOR_ELT(this->data, this->current_row++, (*this->parser_ptr).parse(value, path));
   }
 
@@ -921,21 +832,16 @@ public:
   }
 
   inline void assign_data(SEXP list, SEXP names) const {
-        LOG_VERBOSE;
-
     SET_VECTOR_ELT(list, this->col_location, this->data);
     SET_STRING_ELT(names, this->col_location, this->name);
   }
 };
 
 std::pair<SEXP, std::vector<Collector_Ptr>> parse_fields_spec(cpp11::list spec_list) {
-  LOG_VERBOSE;
-
   cpp11::writable::strings keys;
   std::vector<Collector_Ptr> col_vec;
 
   for (const cpp11::list& elt : spec_list) {
-    LOG_VERBOSE;
     cpp11::r_string key =  cpp11::strings(elt["key"])[0];
     keys.push_back(key);
     cpp11::r_string type = cpp11::strings(elt["type"])[0];
@@ -1004,36 +910,24 @@ std::pair<SEXP, std::vector<Collector_Ptr>> parse_fields_spec(cpp11::list spec_l
     }
   }
 
-  LOG_VERBOSE;
   return std::pair<SEXP, std::vector<Collector_Ptr>>({keys, std::move(col_vec)});
 }
 
 
 [[cpp11::register]]
 SEXP tibblify_impl(SEXP object_list, SEXP spec) {
-  plog::init_r(plog::verbose);
-
-  LOG_VERBOSE << object_list;
-  LOG_VERBOSE << Rf_xlength(object_list);
-
   Path path;
 
   cpp11::list spec_list = spec;
   cpp11::r_string type = cpp11::strings(spec_list["type"])[0];
   auto spec_pair = parse_fields_spec(spec_list["fields"]);
-
-  LOG_VERBOSE;
-
   if (type == "df") {
     cpp11::sexp names_col = spec_list["names_col"];
     if (!Rf_isNull(names_col)) {
       names_col = cpp11::strings(names_col)[0];
     }
 
-    LOG_VERBOSE;
-    SEXP out = Parser_Object_List(spec_pair.first, spec_pair.second, names_col).parse(object_list, path);
-    LOG_VERBOSE;
-    return out;
+    return Parser_Object_List(spec_pair.first, spec_pair.second, names_col).parse(object_list, path);
   } else if (type == "row" || type == "object") {
     // `path.up()` is needed because `parse()` assumes a list of objects and
     // directly uses `path.down()`

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -423,7 +423,6 @@ private:
   int n_fields_prev = 0;
   const int INDEX_SIZE = 256;
   int *ind = (int *) R_alloc(this->INDEX_SIZE, sizeof(int));
-  bool needs_unprotect = false;
 
   inline bool have_fields_changed(SEXP field_names, const int& n_fields) const {
     if (n_fields != this->n_fields_prev) return true;
@@ -459,7 +458,7 @@ private:
   }
 
 protected:
-  SEXP keys;
+  cpp11::writable::strings keys;
   std::vector<Collector_Ptr> collector_vec;
   const int n_keys;
 
@@ -472,8 +471,7 @@ public:
     this->n_fields_prev = Rf_length(keys_);
     this->field_names_prev = keys_;
 
-    this->keys = PROTECT(Rf_allocVector(STRSXP, n_keys));
-    this->needs_unprotect = true;
+    this->keys = Rf_allocVector(STRSXP, n_keys);
     for(int i = 0; i < n_keys; i++) {
       int key_index = this->ind[i];
       SET_STRING_ELT(this->keys, i, STRING_ELT(keys_, key_index));

--- a/tests/testthat/_snaps/tibblify.md
+++ b/tests/testthat/_snaps/tibblify.md
@@ -1,22 +1,22 @@
 # names are checked
 
-    Empty name
+    Element at path <root> has NULL names.
 
 ---
 
-    Empty name
+    Element at path <root> has empty name.
 
 ---
 
-    Empty name
+    Element at path <root> has empty name.
 
 ---
 
-    Empty name
+    Element at path <root> has empty name.
 
 ---
 
-    Duplicate name
+    Element at path <root> has duplicate name.
 
 # scalar column works
 

--- a/tests/testthat/test-tibblify.R
+++ b/tests/testthat/test-tibblify.R
@@ -525,11 +525,11 @@ test_that("discog works", {
   )
 
   expect_equal(tibblify(discog[1], spec_collection), row1)
-  expect_equal(tibblify(row1, spec_collection), row1)
 
-  specs_object <- spec_row(!!!spec_collection$fields)
-  expect_equal(tibblify(discog[[1]], specs_object), row1)
-  expect_equal(tibblify(row1, specs_object), row1)
+  gctorture()
+  on.exit(gctorture(FALSE))
+
+  expect_equal(tibblify(row1, spec_collection), row1)
 })
 
 test_that("spec_object() works", {

--- a/tests/testthat/test-tibblify.R
+++ b/tests/testthat/test-tibblify.R
@@ -526,7 +526,7 @@ test_that("discog works", {
 
   expect_equal(tibblify(discog[1], spec_collection), row1)
 
-  gctorture2(11)
+  gctorture()
   on.exit(gctorture(FALSE))
 
   expect_equal(tibblify(row1, spec_collection), row1)

--- a/tests/testthat/test-tibblify.R
+++ b/tests/testthat/test-tibblify.R
@@ -526,7 +526,7 @@ test_that("discog works", {
 
   expect_equal(tibblify(discog[1], spec_collection), row1)
 
-  gctorture()
+  gctorture2(11)
   on.exit(gctorture(FALSE))
 
   expect_equal(tibblify(row1, spec_collection), row1)


### PR DESCRIPTION
Discovered by running `gctorture2(1001)` before running the tests. We could consider implementing a local version of `test_that()` that turns on `gctorture()` only inside the tests, to speed up the process a bit.

I'll work on simplifying the test case.