### PR TITLE
Give actionable advice in guess_spec()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
 Imports: 
+    cli,
     crayon,
     rlang,
     vctrs,

--- a/R/guess_spec.R
+++ b/R/guess_spec.R
@@ -73,7 +73,13 @@ guess_spec.list <- function(x, simplify_list = TRUE) {
 
   if (is_object(x)) return(guess_object(x, simplify_list))
 
-  abort("Cannot guess spec")
+  cli::cli_abort(c(
+    "Cannot guess spec.",
+    "v" = "The object is a list.",
+    "x" = "It doesn't meet the criteria of {.code tibblify:::is_object_list()}.",
+    "x" = "It doesn't meet the criteria of {.code tibblify:::is_object()}.",
+    "i" = "Try to check the specs of the individual elements with {.code purrr::map(x, guess_spec)}."
+  ))
 }
 
 guess_object_list <- function(x, simplify_list) {


### PR DESCRIPTION
It currently refers to private functions but helps with `gh_repos`.

For #56.

``` r
library(tibblify)

data <- list(list(list(a = 1)), list(list(a = 2)))

guess_spec(data)
#> Error in `guess_spec()`:
#> ! Cannot guess spec.
#> ✔ The object is a list.
#> ✖ It doesn't meet the criteria of `tibblify:::is_object_list()`.
#> ✖ It doesn't meet the criteria of `tibblify:::is_object()`.
#> ℹ Try to check the specs of the individual elements with `purrr::map(x,
#>   guess_spec)`.

purrr::map(data, guess_spec)
#> [[1]]
#> spec_df(
#>   a = tib_dbl("a")
#> )
#> [[2]]
#> spec_df(
#>   a = tib_dbl("a")
#> )
```

<sup>Created on 2022-06-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>