### PR TITLE
Use `NULL` as default in `tib_vector()`

### DIFF
--- a/R/tib_spec.R
+++ b/R/tib_spec.R
@@ -250,9 +250,7 @@ tib_chr <- function(key, required = TRUE, default = NULL, transform = NULL) {
 
 tib_vector_impl <- function(key, ptype, required = TRUE, default = NULL, transform = NULL) {
   ptype <- vec_ptype(ptype)
-  if (is_null(default)) {
-    default <- ptype
-  } else {
+  if (!is_null(default)) {
     default <- vec_cast(default, ptype)
   }
 

--- a/tests/testthat/test-tibblify.R
+++ b/tests/testthat/test-tibblify.R
@@ -151,8 +151,8 @@ test_that("vector column works", {
   expect_snapshot_error(tib(list(x = "a"), tib_lgl_vec("x")))
 
   # fallback default works
-  expect_equal(tib(list(), tib_lgl_vec("x", FALSE)), tibble(x = list_of(logical())))
-  expect_equal(tib(list(), tib_vector("x", dtt, FALSE)), tibble(x = list_of(vctrs::new_datetime())))
+  expect_equal(tib(list(), tib_lgl_vec("x", FALSE)), tibble(x = list_of(NULL, .ptype = logical())))
+  expect_equal(tib(list(), tib_vector("x", dtt, FALSE)), tibble(x = list_of(NULL, .ptype = vctrs::new_datetime())))
 
   # specified default works
   expect_equal(tib(list(), tib_lgl_vec("x", FALSE, c(TRUE, FALSE))), tibble(x = list_of(c(TRUE, FALSE))))


### PR DESCRIPTION
Closes #35.