### PR TITLE
Handle non-vector elements

### DIFF
--- a/R/spec_guess_list.R
+++ b/R/spec_guess_list.R
@@ -62,6 +62,14 @@ guess_field_spec <- function(value,
     if (!ptype_result$has_common_ptype) return(tib_variant(name, required))
     ptype <- ptype_result$ptype
   } else {
+    if (is_null(value)) {
+      return(tib_unspecified(name, required))
+    }
+
+    if (!vec_is(value)) {
+      return(tib_variant(name, required))
+    }
+
     ptype <- vec_ptype(value)
     ptype <- special_ptype_handling(ptype)
   }

--- a/tests/testthat/test-spec_guess_object.R
+++ b/tests/testthat/test-spec_guess_object.R
@@ -26,9 +26,11 @@ test_that("POSIXlt is converted to POSIXct", {
 })
 
 test_that("can handle non-vector elements", {
-  skip("Not yet working - #76")
   model <- lm(Sepal.Length ~ Sepal.Width, data = iris)
-  spec_guess_object(list(x = model))
+  expect_equal(
+    spec_guess_object(list(x = model)),
+    spec_object(x = tib_variant("x"))
+  )
 })
 
 test_that("can guess vector elements", {
@@ -81,12 +83,10 @@ test_that("can guess mixed elements", {
   )
 })
 
-test_that("non-vector objects work", {
-  skip("handling of non-vector objects not yet decided - #84")
-  # non-vector objects are okay in lists
+test_that("can handle non-vector elements in list", {
   model <- lm(Sepal.Length ~ Sepal.Width, data = iris)
   expect_equal(
-    spec_guess_object(list(x = list(TRUE, model))),
+    spec_guess_object(list(x = list(model, model))),
     spec_object(x = tib_variant("x"))
   )
 })

--- a/tests/testthat/test-spec_guess_object_list.R
+++ b/tests/testthat/test-spec_guess_object_list.R
@@ -114,8 +114,9 @@ test_that("can guess tib_variant", {
     ),
     spec_df(x = tib_variant("x"))
   )
+})
 
-  # non-vector objects are okay in lists
+test_that("can handle non-vector elements", {
   model <- lm(Sepal.Length ~ Sepal.Width, data = iris)
   expect_equal(
     spec_guess_object_list(


### PR DESCRIPTION
Closes #84 and closes #76.
For now non-vector elements are simply put in `tib_variant()`. Maybe `tib_variant()` could later gain a `f_check` argument, so that the user can provide a custom function to check whether the input is valid.