### PR TITLE
Support input and output form in `tib_vector()`

### DIFF
--- a/R/format.R
+++ b/R/format.R
@@ -91,7 +91,12 @@ format.tib_scalar <- function(x, ...,
     ptype = if (class(x)[1] == "tib_scalar" || class(x)[1] == "tib_vector") format_ptype(x$ptype),
     required = if (!x$required) FALSE,
     default = format_default(x$default_value, x$ptype),
-    transform = x$transform
+    transform = x$transform,
+    input_form = if (!is_null(x$input_form) && x$input_form != "vector") {
+      paste0('"', x$input_form, '"')
+    },
+    values_to = x$values_to,
+    names_to = x$names_to
   )
   parts <- purrr::discard(parts, is.null)
 

--- a/R/format.R
+++ b/R/format.R
@@ -84,11 +84,6 @@ print.tib_collector <- function(x, ...) {
 }
 
 #' @export
-format.tib_vector <- function(x, ...) {
-  format.tib_collector(x, ptype = deparse(x$ptype), ...)
-}
-
-#' @export
 format.tib_scalar <- function(x, ...,
                               multi_line = FALSE, nchar_indent = 0, width = NULL) {
   parts <- list(

--- a/R/format.R
+++ b/R/format.R
@@ -95,8 +95,8 @@ format.tib_scalar <- function(x, ...,
     input_form = if (!is_null(x$input_form) && x$input_form != "vector") {
       paste0('"', x$input_form, '"')
     },
-    values_to = x$values_to,
-    names_to = x$names_to
+    values_to = if (!is_null(x$values_to)) paste0('"', x$values_to, '"'),
+    names_to = if (!is_null(x$names_to)) paste0('"', x$names_to, '"')
   )
   parts <- purrr::discard(parts, is.null)
 

--- a/R/tib_spec.R
+++ b/R/tib_spec.R
@@ -313,10 +313,6 @@ tib_vector_impl <- function(key,
     default <- vec_cast(default, ptype)
   }
   if (!is_null(values_to)) {
-    if (!input_form %in% c("scalar_list", "object")) {
-      msg <- "{.arg values_to} can only be used if {.arg input_form} is {.val scalar_list} or {.val object}."
-      cli::cli_abort(msg, call = call)
-    }
     values_to <- vec_cast(values_to, character())
     vec_assert(values_to, size = 1, call = call)
   }
@@ -325,6 +321,11 @@ tib_vector_impl <- function(key,
       msg <- "{.arg names_to} can only be used if {.arg values_to} is not {.code NULL}."
       cli::cli_abort(msg, call = call)
     }
+    if (input_form != "object") {
+      msg <- "{.arg names_to} can only be used if {.arg input_form} is {.val object}."
+      cli::cli_abort(msg, call = call)
+    }
+
     names_to <- vec_cast(names_to, character())
     vec_assert(names_to, size = 1, call = call)
   }

--- a/R/tib_spec.R
+++ b/R/tib_spec.R
@@ -187,6 +187,20 @@ tib_has_special_scalar.character <- function(ptype) vec_is(ptype, character())
 #' @param required,.required Throw an error if the field does not exist?
 #' @param default Default value to use if the field does not exist.
 #' @param transform A function to apply to the field before casting to `ptype`.
+#' @param input_form A string that describes what structure the field has. Can
+#'   be one of:
+#'   * `"vector"`: The field is a vector, e.g. `c(1, 2, 3)`.
+#'   * `"scalar_list"`: The field is a list of scalars, e.g. `list(1, 2, 3)`.
+#'   * `"object"`: The field is a named list of scalars, e.g. `list(a = 1, b = 2, c = 3)`.
+#' @param values_to Can be one of the following:
+#'   * `NULL`: the default. The field is converted to a `ptype` vector.
+#'   * A string: The field is converted to a tibble and the values go into the
+#'     specified column.
+#' @param names_to Can be one of the following:
+#'   * `NULL`: the default. The inner names of the field are not used.
+#'   * A string: This can only be used if 1) `input_form = "object"` and
+#'     2) `values_to` is a string. The inner names of the field go into the
+#'     specified column.
 #' @inheritParams spec_df
 #'
 #' @details There are basically five different `tib_*()` functions
@@ -287,11 +301,32 @@ tib_vector_impl <- function(key,
                             ...,
                             required = TRUE,
                             default = NULL,
-                            transform = NULL) {
+                            transform = NULL,
+                            input_form = c("vector", "scalar_list", "object"),
+                            values_to = NULL,
+                            names_to = NULL,
+                            call = caller_env()) {
   check_dots_empty()
+  input_form <- arg_match0(input_form, c("vector", "scalar_list", "object"))
   ptype <- vec_ptype(ptype)
   if (!is_null(default)) {
     default <- vec_cast(default, ptype)
+  }
+  if (!is_null(values_to)) {
+    if (!input_form %in% c("scalar_list", "object")) {
+      msg <- "{.arg values_to} can only be used if {.arg input_form} is {.val scalar_list} or {.val object}."
+      cli::cli_abort(msg, call = call)
+    }
+    values_to <- vec_cast(values_to, character())
+    vec_assert(values_to, size = 1, call = call)
+  }
+  if (!is_null(names_to)) {
+    if (is_null(values_to)) {
+      msg <- "{.arg names_to} can only be used if {.arg values_to} is not {.code NULL}."
+      cli::cli_abort(msg, call = call)
+    }
+    names_to <- vec_cast(names_to, character())
+    vec_assert(names_to, size = 1, call = call)
   }
 
   class <- NULL
@@ -306,6 +341,9 @@ tib_vector_impl <- function(key,
     ptype = ptype,
     default_value = default,
     transform = prep_transform(transform),
+    input_form = input_form,
+    values_to = values_to,
+    names_to = names_to,
     class = class
   )
 }
@@ -332,14 +370,21 @@ tib_vector <- function(key,
                        ...,
                        required = TRUE,
                        default = NULL,
-                       transform = NULL) {
+                       transform = NULL,
+                       input_form = c("vector", "scalar_list", "object"),
+                       values_to = NULL,
+                       names_to = NULL) {
   check_dots_empty()
+  input_form <- arg_match0(input_form, c("vector", "scalar_list", "object"))
   tib_vector_impl(
     key = key,
     required = required,
     ptype = ptype,
     default = default,
-    transform = transform
+    transform = transform,
+    input_form = input_form,
+    values_to = values_to,
+    names_to = names_to
   )
 }
 
@@ -349,9 +394,22 @@ tib_lgl_vec <- function(key,
                         ...,
                         required = TRUE,
                         default = NULL,
-                        transform = NULL) {
+                        transform = NULL,
+                        input_form = c("vector", "scalar_list", "object"),
+                        values_to = NULL,
+                        names_to = NULL) {
   check_dots_empty()
-  tib_vector_impl(key, ptype = logical(), required = required, default = default, transform = transform)
+  input_form <- arg_match0(input_form, c("vector", "scalar_list", "object"))
+  tib_vector_impl(
+    key,
+    ptype = logical(),
+    required = required,
+    default = default,
+    transform = transform,
+    input_form = input_form,
+    values_to = values_to,
+    names_to = names_to
+  )
 }
 
 #' @rdname tib_scalar
@@ -360,9 +418,22 @@ tib_int_vec <- function(key,
                         ...,
                         required = TRUE,
                         default = NULL,
-                        transform = NULL) {
+                        transform = NULL,
+                        input_form = c("vector", "scalar_list", "object"),
+                        values_to = NULL,
+                        names_to = NULL) {
   check_dots_empty()
-  tib_vector_impl(key, ptype = integer(), required = required, default = default, transform = transform)
+  input_form <- arg_match0(input_form, c("vector", "scalar_list", "object"))
+  tib_vector_impl(
+    key,
+    ptype = integer(),
+    required = required,
+    default = default,
+    transform = transform,
+    input_form = input_form,
+    values_to = values_to,
+    names_to = names_to
+  )
 }
 
 #' @rdname tib_scalar
@@ -371,9 +442,22 @@ tib_dbl_vec <- function(key,
                         ...,
                         required = TRUE,
                         default = NULL,
-                        transform = NULL) {
+                        transform = NULL,
+                        input_form = c("vector", "scalar_list", "object"),
+                        values_to = NULL,
+                        names_to = NULL) {
   check_dots_empty()
-  tib_vector_impl(key, ptype = double(), required = required, default = default, transform = transform)
+  input_form <- arg_match0(input_form, c("vector", "scalar_list", "object"))
+  tib_vector_impl(
+    key,
+    ptype = double(),
+    required = required,
+    default = default,
+    transform = transform,
+    input_form = input_form,
+    values_to = values_to,
+    names_to = names_to
+  )
 }
 
 #' @rdname tib_scalar
@@ -382,9 +466,22 @@ tib_chr_vec <- function(key,
                         ...,
                         required = TRUE,
                         default = NULL,
-                        transform = NULL) {
+                        transform = NULL,
+                        input_form = c("vector", "scalar_list", "object"),
+                        values_to = NULL,
+                        names_to = NULL) {
   check_dots_empty()
-  tib_vector_impl(key, ptype = character(), required = required, default = default, transform = transform)
+  input_form <- arg_match0(input_form, c("vector", "scalar_list", "object"))
+  tib_vector_impl(
+    key,
+    ptype = character(),
+    required = required,
+    default = default,
+    transform = transform,
+    input_form = input_form,
+    values_to = values_to,
+    names_to = names_to
+  )
 }
 
 

--- a/R/tib_spec.R
+++ b/R/tib_spec.R
@@ -328,6 +328,10 @@ tib_vector_impl <- function(key,
 
     names_to <- vec_cast(names_to, character())
     vec_assert(names_to, size = 1, call = call)
+    if (names_to == values_to) {
+      msg <- "{.arg names_to} must be different from {.arg values_to}."
+      cli::cli_abort(msg, call = call)
+    }
   }
 
   class <- NULL

--- a/R/tibblify.R
+++ b/R/tibblify.R
@@ -116,7 +116,7 @@ prep_nested_keys <- function(spec, shift = FALSE) {
             c(x$names_to, x$values_to)
           )
         }
-        x$default_value <- as_tibble(default_value_list)
+        x$default_value <- tibble::as_tibble(default_value_list)
       }
 
       x

--- a/R/tibblify.R
+++ b/R/tibblify.R
@@ -104,6 +104,21 @@ prep_nested_keys <- function(spec, shift = FALSE) {
         x$fields <- spec_prep(x$fields, shift = !is.null(x$names_col))
       }
 
+      if (x$type == "vector" && !is_null(x$values_to) && !is_null(x$default_value)) {
+        if (is_null(x$names_to)) {
+          default_value_list <- set_names(
+            list(unname(x$default_value)),
+            x$values_to
+          )
+        } else {
+          default_value_list <- set_names(
+            list(names(x$default_value), unname(x$default_value)),
+            c(x$names_to, x$values_to)
+          )
+        }
+        x$default_value <- as_tibble(default_value_list)
+      }
+
       x
     }
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -64,6 +64,12 @@ stop_vector_non_list_element <- function(path, input_form) {
   cli::cli_abort(msg)
 }
 
+stop_vector_wrong_size_element <- function(path, input_form) {
+  path_str <- path_to_string(path)
+  msg <- 'Each element in list at path {path_str} must have size 1.'
+  cli::cli_abort(msg)
+}
+
 vec_flatten <- function(x, ptype) {
   vctrs::vec_unchop(x, ptype = ptype)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -57,6 +57,13 @@ stop_names_is_null <- function(path) {
   abort(message)
 }
 
+stop_vector_non_list_element <- function(path, input_form) {
+  # FIXME {.code} cannot be interpolated correctly
+  path_str <- path_to_string(path)
+  msg <- 'Element at path {path_str} must be a list for `input_form = "{input_form}"`'
+  cli::cli_abort(msg)
+}
+
 vec_flatten <- function(x, ptype) {
   vctrs::vec_unchop(x, ptype = ptype)
 }

--- a/man/tib_scalar.Rd
+++ b/man/tib_scalar.Rd
@@ -29,15 +29,61 @@ tib_dbl(key, ..., required = TRUE, default = NULL, transform = NULL)
 
 tib_chr(key, ..., required = TRUE, default = NULL, transform = NULL)
 
-tib_vector(key, ptype, ..., required = TRUE, default = NULL, transform = NULL)
+tib_vector(
+  key,
+  ptype,
+  ...,
+  required = TRUE,
+  default = NULL,
+  transform = NULL,
+  input_form = c("vector", "scalar_list", "object"),
+  values_to = NULL,
+  names_to = NULL
+)
 
-tib_lgl_vec(key, ..., required = TRUE, default = NULL, transform = NULL)
+tib_lgl_vec(
+  key,
+  ...,
+  required = TRUE,
+  default = NULL,
+  transform = NULL,
+  input_form = c("vector", "scalar_list", "object"),
+  values_to = NULL,
+  names_to = NULL
+)
 
-tib_int_vec(key, ..., required = TRUE, default = NULL, transform = NULL)
+tib_int_vec(
+  key,
+  ...,
+  required = TRUE,
+  default = NULL,
+  transform = NULL,
+  input_form = c("vector", "scalar_list", "object"),
+  values_to = NULL,
+  names_to = NULL
+)
 
-tib_dbl_vec(key, ..., required = TRUE, default = NULL, transform = NULL)
+tib_dbl_vec(
+  key,
+  ...,
+  required = TRUE,
+  default = NULL,
+  transform = NULL,
+  input_form = c("vector", "scalar_list", "object"),
+  values_to = NULL,
+  names_to = NULL
+)
 
-tib_chr_vec(key, ..., required = TRUE, default = NULL, transform = NULL)
+tib_chr_vec(
+  key,
+  ...,
+  required = TRUE,
+  default = NULL,
+  transform = NULL,
+  input_form = c("vector", "scalar_list", "object"),
+  values_to = NULL,
+  names_to = NULL
+)
 
 tib_variant(key, ..., required = TRUE, default = NULL, transform = NULL)
 
@@ -57,6 +103,29 @@ tib_df(.key, ..., .required = TRUE, .names_to = NULL)
 \item{default}{Default value to use if the field does not exist.}
 
 \item{transform}{A function to apply to the field before casting to \code{ptype}.}
+
+\item{input_form}{A string that describes what structure the field has. Can
+be one of:
+\itemize{
+\item \code{"vector"}: The field is a vector, e.g. \code{c(1, 2, 3)}.
+\item \code{"scalar_list"}: The field is a list of scalars, e.g. \code{list(1, 2, 3)}.
+\item \code{"object"}: The field is a named list of scalars, e.g. \code{list(a = 1, b = 2, c = 3)}.
+}}
+
+\item{values_to}{Can be one of the following:
+\itemize{
+\item \code{NULL}: the default. The field is converted to a \code{ptype} vector.
+\item A string: The field is converted to a tibble and the values go into the
+specified column.
+}}
+
+\item{names_to}{Can be one of the following:
+\itemize{
+\item \code{NULL}: the default. The inner names of the field are not used.
+\item A string: This can only be used if 1) \code{input_form = "object"} and
+2) \code{values_to} is a string. The inner names of the field go into the
+specified column.
+}}
 
 \item{.names_to}{A string giving the name of the column which will contain
 the names of elements of the object list. If \code{NULL}, the default, no name

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -44,7 +44,7 @@ inline void stop_names_is_null(const Path& path) {
 }
 
 inline void stop_vector_non_list_element(const Path& path, vector_input_form input_form) {
-  std::string input_form_string;
+  cpp11::r_string input_form_string;
   switch (input_form) {
   case scalar_list: {input_form_string = "scalar_list";} break;
   case vector: {input_form_string = "vector";} break;
@@ -53,7 +53,7 @@ inline void stop_vector_non_list_element(const Path& path, vector_input_form inp
 
   SEXP call = PROTECT(Rf_lang3(Rf_install("stop_vector_non_list_element"),
                                PROTECT(path.data()),
-                               cpp11::r_string(input_form_string)));
+                               cpp11::as_sexp(input_form_string)));
   Rf_eval(call, tibblify_ns_env);
 }
 

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -373,31 +373,6 @@ private:
     }
   }
 
-  SEXP get_default_value(SEXP default_value_, SEXP ptype_, SEXP names_to_, SEXP values_to_) {
-    // TODO first initialize `this->output_col_names`, `this->uses_values_col`, and `this->uses_names_col` to use it in here?
-    SEXP default_value_casted = vec_cast(default_value_, ptype_);
-    if (Rf_isNull(values_to_)) {
-      return(default_value_casted);
-    }
-
-    SEXP col_names = get_output_col_names(names_to_, values_to_);
-    R_len_t n_rows = vec_size(default_value_casted);
-    cpp11::writable::list out = init_df(n_rows, col_names);
-    if (Rf_isNull(names_to_)) {
-      out[0] = default_value_casted;
-    } else {
-      // TODO this could use the names of the default value?
-      auto names = cpp11::writable::strings(n_rows);
-      for (int i = 0; i < n_rows; i++) {
-        names[i] = cpp11::na<cpp11::r_string>();
-      }
-      out[0] = names;
-      out[1] = default_value_casted;
-    }
-
-    return(out);
-  }
-
   cpp11::writable::list init_out_df(R_xlen_t n_rows) {
     cpp11::writable::list ptype_out(init_df(n_rows, this->output_col_names));
 
@@ -453,7 +428,7 @@ public:
                    SEXP name_, SEXP transform_, cpp11::r_string input_form_,
                    SEXP names_to_, SEXP values_to_)
     : Collector_Scalar_Base(required_, col_location_, name_, transform_)
-  , default_value(get_default_value(default_value_, ptype_, names_to_, values_to_))
+  , default_value(default_value_)
   , ptype(ptype_)
   , input_form(string_to_form_enum(input_form_))
   , uses_names_col(!Rf_isNull(names_to_))

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -485,7 +485,16 @@ public:
 
       if (this->uses_names_col) {
         // this can only be if `input_form == object` so no need to check
-        df[0] = names;
+        if (Rf_isNull(names)) {
+          // TODO unclear what to do in such a case
+          auto names2 = cpp11::writable::strings(size);
+          for (int i = 0; i < size; i++) {
+            names2[i] = cpp11::na<cpp11::r_string>();
+          }
+          df[0] = names2;
+        } else {
+          df[0] = names;
+        }
         df[1] = value_casted;
       } else {
         df[0] = value_casted;

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -373,6 +373,31 @@ private:
     }
   }
 
+  SEXP get_default_value(SEXP default_value_, SEXP ptype_, SEXP names_to_, SEXP values_to_) {
+    // TODO first initialize `this->output_col_names`, `this->uses_values_col`, and `this->uses_names_col` to use it in here?
+    SEXP default_value_casted = vec_cast(default_value_, ptype_);
+    if (Rf_isNull(values_to_)) {
+      return(default_value_casted);
+    }
+
+    SEXP col_names = get_output_col_names(names_to_, values_to_);
+    R_len_t n_rows = vec_size(default_value_casted);
+    cpp11::writable::list out = init_df(n_rows, col_names);
+    if (Rf_isNull(names_to_)) {
+      out[0] = default_value_casted;
+    } else {
+      // TODO this could use the names of the default value?
+      auto names = cpp11::writable::strings(n_rows);
+      for (int i = 0; i < n_rows; i++) {
+        names[i] = cpp11::na<cpp11::r_string>();
+      }
+      out[0] = names;
+      out[1] = default_value_casted;
+    }
+
+    return(out);
+  }
+
   cpp11::writable::list init_out_df(R_xlen_t n_rows) {
     cpp11::writable::list ptype_out(init_df(n_rows, this->output_col_names));
 
@@ -428,7 +453,7 @@ public:
                    SEXP name_, SEXP transform_, cpp11::r_string input_form_,
                    SEXP names_to_, SEXP values_to_)
     : Collector_Scalar_Base(required_, col_location_, name_, transform_)
-  , default_value(vec_cast(default_value_, ptype_))
+  , default_value(get_default_value(default_value_, ptype_, names_to_, values_to_))
   , ptype(ptype_)
   , input_form(string_to_form_enum(input_form_))
   , uses_names_col(!Rf_isNull(names_to_))

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -57,6 +57,13 @@ inline void stop_vector_non_list_element(const Path& path, vector_input_form inp
   Rf_eval(call, tibblify_ns_env);
 }
 
+inline void stop_vector_wrong_size_element(const Path& path, vector_input_form input_form) {
+  SEXP call = PROTECT(Rf_lang3(Rf_install("stop_vector_wrong_size_element"),
+                               PROTECT(path.data()),
+                               vector_input_form_to_sexp(input_form)));
+  Rf_eval(call, tibblify_ns_env);
+}
+
 inline SEXP apply_transform(SEXP value, SEXP fn) {
   // from https://github.com/r-lib/vctrs/blob/9b65e090da2a0f749c433c698a15d4e259422542/src/names.c#L83
   SEXP call = PROTECT(Rf_lang2(syms_transform, syms_value));
@@ -421,8 +428,7 @@ private:
       }
 
       if (vec_size(*ptr_row) != 1) {
-        // TODO better error message
-        cpp11::stop("Each element must have size one.");
+        stop_vector_wrong_size_element(path, this->input_form);
       }
 
       out_list[i] = *ptr_row;

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -144,7 +144,7 @@ public:
   }
 
   inline void assign_data(SEXP list, SEXP names) const {
-    SEXP call = PROTECT(Rf_lang3(Rf_install("vec_flatten"),
+    SEXP call = PROTECT(Rf_lang3(syms_vec_flatten,
                                  this->data,
                                  this->ptype));
     SEXP value = R_tryEval(call, tibblify_ns_env, NULL);
@@ -341,21 +341,128 @@ protected:
   int current_row = 0;
 private:
   cpp11::writable::list data;
+  const vector_input_form input_form;
+  const bool uses_names_col;
+  const bool uses_values_col;
+  const SEXP output_col_names;
+
+  vector_input_form string_to_form_enum(cpp11::r_string input_form_) {
+    if (input_form_ == "vector") {
+      return(vector);
+    } else if (input_form_ == "scalar_list") {
+      return(scalar_list);
+    } else if (input_form_ == "object") {
+      return(object);
+    } else{
+      cpp11::stop("Internal error.");
+    }
+  }
+
+  SEXP get_output_col_names(SEXP names_to_, SEXP values_to_) {
+    if (Rf_isNull(values_to_)) {
+      return(NULL);
+    }
+
+    if (Rf_isNull(names_to_)) {
+      return(values_to_);
+    } else {
+      cpp11::writable::strings col_names_(2);
+      col_names_[0] = cpp11::strings(names_to_)[0];
+      col_names_[1] = cpp11::strings(values_to_)[0];
+      return(col_names_);
+    }
+  }
+
+  cpp11::writable::list init_out_df(R_xlen_t n_rows) {
+    cpp11::writable::list ptype_out(init_df(n_rows, this->output_col_names));
+
+    return(ptype_out);
+  }
+
+  SEXP unchop_value(SEXP value) {
+    if (Rf_isNull(value)) {
+      return(value);
+    }
+
+    // FIXME should check with `vec_is_list()`
+    if (TYPEOF(value) != VECSXP) {
+      // TODO better error message
+      cpp11::stop("Field value must be a list for `scalar_list` or `object`");
+    }
+
+    cpp11::integers n1({1});
+    SEXP vec_init_call = PROTECT(Rf_lang3(syms_vec_init,
+                                          this->ptype,
+                                          tibblify_shared_int1));
+    SEXP missing_value = R_tryEval(vec_init_call, tibblify_ns_env, NULL);
+
+    // FIXME if `vec_assign()` gets exported this should use
+    // `vec_init()` + `vec_assign()`
+    R_xlen_t n = Rf_length(value);
+    const SEXP* ptr_row = VECTOR_PTR_RO(value);
+    cpp11::writable::list out_list(n);
+    for (R_xlen_t i = 0; i < n; i++, ptr_row++) {
+      if (Rf_isNull(*ptr_row)) {
+        out_list[i] = missing_value;
+        continue;
+      }
+
+      if (vec_size(*ptr_row) != 1) {
+        // TODO better error message
+        cpp11::stop("Each element must have size one.");
+      }
+
+      out_list[i] = *ptr_row;
+    }
+
+    SEXP call = PROTECT(Rf_lang3(syms_vec_flatten,
+                                 out_list,
+                                 this->ptype));
+    SEXP out = R_tryEval(call, tibblify_ns_env, NULL);
+    UNPROTECT(2);
+    return(out);
+  }
 
 public:
   Collector_Vector(SEXP default_value_, bool required_, SEXP ptype_, int col_location_,
-                   SEXP name_, SEXP transform_)
+                   SEXP name_, SEXP transform_, cpp11::r_string input_form_,
+                   SEXP names_to_, SEXP values_to_)
     : Collector_Scalar_Base(required_, col_location_, name_, transform_)
   , default_value(vec_cast(default_value_, ptype_))
   , ptype(ptype_)
+  , input_form(string_to_form_enum(input_form_))
+  , uses_names_col(!Rf_isNull(names_to_))
+  , uses_values_col(!Rf_isNull(values_to_))
+  , output_col_names(get_output_col_names(names_to_, values_to_))
   { }
 
   inline void init(R_xlen_t& length) {
-    this->data = init_list_of(length, this->ptype);
+    if (this->uses_values_col) {
+      auto ptype_df = init_out_df(0);
+      if (this->uses_names_col) {
+        ptype_df[0] = tibblify_shared_empty_chr;
+        ptype_df[1] = this->ptype;
+      } else {
+        ptype_df[0] = this->ptype;
+      }
+      this->data = init_list_of(length, ptype_df);
+    } else {
+      this->data = init_list_of(length, this->ptype);
+    }
+
     this->current_row = 0;
   }
 
   inline void add_value(SEXP value, Path& path) {
+    SEXP names;
+    if (this->uses_names_col) {
+      names = Rf_getAttrib(value, R_NamesSymbol);
+    }
+
+    if (this->input_form == scalar_list || this->input_form == object) {
+      value = unchop_value(value);
+    }
+
     // TODO use `NULL` if `value` is empty?
     if (!Rf_isNull(this->transform)) value = apply_transform(value, this->transform);
     // TODO should be controlled via an argument to `tibblify()`
@@ -365,16 +472,34 @@ public:
     }
 
     SEXP value_casted = vec_cast(PROTECT(value), ptype);
-    SET_VECTOR_ELT(this->data, this->current_row++, value_casted);
+
+    if (this->uses_values_col) {
+      R_len_t size = short_vec_size(value_casted);
+      cpp11::writable::list df = init_out_df(size);
+
+      if (this->uses_names_col) {
+        // this can only be if `input_form == object` so no need to check
+        df[0] = names;
+        df[1] = value_casted;
+      } else {
+        df[0] = value_casted;
+      }
+
+      SET_VECTOR_ELT(this->data, this->current_row++, df);
+    } else {
+      SET_VECTOR_ELT(this->data, this->current_row++, value_casted);
+    }
     UNPROTECT(1);
   }
 
   inline void add_default(Path& path) {
     if (required) stop_required(path);
+    // TODO what if output form is a tibble and names_to?
     SET_VECTOR_ELT(this->data, this->current_row++, this->default_value);
   }
 
   inline void add_default_df() {
+    // TODO what if output form is a tibble and names_to?
     SET_VECTOR_ELT(this->data, this->current_row++, this->default_value);
   }
 
@@ -908,7 +1033,20 @@ std::pair<SEXP, std::vector<Collector_Ptr>> parse_fields_spec(cpp11::list spec_l
         col_vec.push_back(std::unique_ptr<Collector_Scalar>(new Collector_Scalar(default_sexp, required, ptype, location, name, transform)));
       }
     } else if (type == "vector") {
-      col_vec.push_back(std::unique_ptr<Collector_Vector>(new Collector_Vector(default_sexp, required, ptype, location, name, transform)));
+      cpp11::r_string input_form = cpp11::strings(elt["input_form"])[0];
+      cpp11::sexp names_to = elt["names_to"];
+      cpp11::sexp values_to = elt["values_to"];
+      col_vec.push_back(std::unique_ptr<Collector_Vector>(new Collector_Vector(
+          default_sexp,
+          required,
+          ptype,
+          location,
+          name,
+          transform,
+          input_form,
+          names_to,
+          values_to))
+      );
     } else {
       cpp11::stop("Internal Error: Unsupported type");
     }

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -401,8 +401,6 @@ private:
     // FIXME should check with `vec_is_list()`
     if (TYPEOF(value) != VECSXP) {
       stop_vector_non_list_element(path, this->input_form);
-      // TODO better error message
-      cpp11::stop("Field value must be a list for `scalar_list` or `object`");
     }
 
     cpp11::integers n1({1});

--- a/src/collector-method.cpp
+++ b/src/collector-method.cpp
@@ -474,6 +474,12 @@ public:
     SEXP value_casted = vec_cast(PROTECT(value), ptype);
 
     if (this->uses_values_col) {
+      if (Rf_isNull(value_casted)) {
+        SET_VECTOR_ELT(this->data, this->current_row++, R_NilValue);
+        UNPROTECT(1);
+        return;
+      }
+
       R_len_t size = short_vec_size(value_casted);
       cpp11::writable::list df = init_out_df(size);
 

--- a/src/tibblify.h
+++ b/src/tibblify.h
@@ -31,6 +31,8 @@ extern SEXP tibblify_shared_empty_list;
 // extern SEXP tibblify_shared_empty_date;
 // extern SEXP tibblify_shared_empty_uns;
 
+extern SEXP tibblify_shared_int1;
+
 extern SEXP syms_transform;
 extern SEXP syms_value;
 extern SEXP syms_x;
@@ -39,5 +41,7 @@ extern SEXP syms_ptype;
 extern SEXP syms_vec_is_list;
 extern SEXP syms_vec_is;
 extern SEXP syms_vec_names2;
+extern SEXP syms_vec_flatten;
+extern SEXP syms_vec_init;
 
 #endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -22,6 +22,8 @@ SEXP tibblify_shared_empty_list = NULL;
 // SEXP tibblify_shared_empty_date = NULL;
 // SEXP tibblify_shared_empty_uns = NULL;
 
+SEXP tibblify_shared_int1 = NULL;
+
 // SEXP classes_date = NULL;
 SEXP classes_tibble = NULL;
 SEXP classes_list_of = NULL;
@@ -35,6 +37,7 @@ SEXP syms_vec_is_list = NULL;
 SEXP syms_vec_is = NULL;
 SEXP syms_vec_flatten = NULL;
 SEXP syms_vec_names2 = NULL;
+SEXP syms_vec_init = NULL;
 
 SEXP r_new_shared_vector(SEXPTYPE type, R_len_t n) {
   SEXP out = Rf_allocVector(type, n);
@@ -88,6 +91,9 @@ void tibblify_init_utils(SEXP ns) {
   // Rf_setAttrib(tibblify_shared_empty_date, R_ClassSymbol, classes_date);
   // tibblify_shared_empty_uns = r_new_shared_vector(LGLSXP, 0);
 
+  tibblify_shared_int1 = r_new_shared_vector(INTSXP, 1);
+  INTEGER(tibblify_shared_int1)[0] = 1;
+
   syms_ptype = Rf_install("ptype");
   syms_transform = Rf_install("transform");
   syms_value = Rf_install("value");
@@ -97,6 +103,7 @@ void tibblify_init_utils(SEXP ns) {
   syms_vec_is_list = Rf_findFun(Rf_install("vec_is_list"), vctrs_package);
   syms_vec_is = Rf_findFun(Rf_install("vec_is"), vctrs_package);
   syms_vec_names2 = Rf_findFun(Rf_install("vec_names2"), vctrs_package);
+  syms_vec_init = Rf_findFun(Rf_install("vec_init"), vctrs_package);
 
   SEXP tibblify_symbol = Rf_install("tibblify");
   SEXP tibblify_package = Rf_findVarInFrame(R_NamespaceRegistry, tibblify_symbol);

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,6 +1,8 @@
 #include <cpp11.hpp>
 #include "tibblify.h"
 
+enum vector_input_form {vector, scalar_list, object};
+
 inline
 SEXP set_df_attributes(SEXP list, R_xlen_t n_rows) {
   Rf_setAttrib(list, R_ClassSymbol, classes_tibble);

--- a/src/utils.h
+++ b/src/utils.h
@@ -3,6 +3,17 @@
 
 enum vector_input_form {vector, scalar_list, object};
 
+inline cpp11::sexp vector_input_form_to_sexp(vector_input_form input_form) {
+  cpp11::r_string input_form_string;
+  switch (input_form) {
+  case scalar_list: {input_form_string = "scalar_list";} break;
+  case vector: {input_form_string = "vector";} break;
+  case object: {input_form_string = "object";} break;
+  }
+
+  return(cpp11::as_sexp(input_form_string));
+}
+
 inline
 SEXP set_df_attributes(SEXP list, R_xlen_t n_rows) {
   Rf_setAttrib(list, R_ClassSymbol, classes_tibble);

--- a/tests/testthat/_snaps/format.md
+++ b/tests/testthat/_snaps/format.md
@@ -130,15 +130,15 @@
 ---
 
     Code
-      tib_vector("a", ptype = Sys.Date(), input_form = "scalar_list", values_to = "vals",
+      tib_vector("a", ptype = Sys.Date(), input_form = "object", values_to = "vals",
       names_to = "names") %>% print()
     Output
       tib_vector(
         "a",
         ptype = vctrs::new_date(),
-        input_form = "scalar_list",
-        values_to = vals,
-        names_to = names,
+        input_form = "object",
+        values_to = "vals",
+        names_to = "names",
       )
 
 # format for tib_row works

--- a/tests/testthat/_snaps/format.md
+++ b/tests/testthat/_snaps/format.md
@@ -127,6 +127,20 @@
     Output
       tib_vector("a", ptype = vctrs::new_date())
 
+---
+
+    Code
+      tib_vector("a", ptype = Sys.Date(), input_form = "scalar_list", values_to = "vals",
+      names_to = "names") %>% print()
+    Output
+      tib_vector(
+        "a",
+        ptype = vctrs::new_date(),
+        input_form = "scalar_list",
+        values_to = vals,
+        names_to = names,
+      )
+
 # format for tib_row works
 
     Code

--- a/tests/testthat/_snaps/tib_spec.md
+++ b/tests/testthat/_snaps/tib_spec.md
@@ -49,3 +49,58 @@
       * "a" at locations 1 and 3.
       * "b" at locations 2 and 4.
 
+# tib_vector checks arguments
+
+    Code
+      (expect_error(tib_int_vec("x", input_form = "v")))
+    Output
+      <error/rlang_error>
+      Error in `tib_int_vec()`:
+      ! `input_form` must be one of "vector", "scalar_list", or "object", not "v".
+      i Did you mean "vector"?
+    Code
+      (expect_error(tib_int_vec("x", values_to = 1)))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `tib_vector_impl()`:
+      ! Can't convert `values_to` <double> to <character>.
+    Code
+      (expect_error(tib_int_vec("x", values_to = c("a", "b"))))
+    Output
+      <error/vctrs_error_assert_size>
+      Error in `tib_int_vec()`:
+      ! `values_to` must have size 1, not size 2.
+    Code
+      (expect_error(tib_int_vec("x", values_to = "val", names_to = "name")))
+    Output
+      <error/rlang_error>
+      Error in `tib_int_vec()`:
+      ! `names_to` can only be used if `input_form` is "object".
+    Code
+      (expect_error(tib_int_vec("x", input_form = "object", names_to = "name")))
+    Output
+      <error/rlang_error>
+      Error in `tib_int_vec()`:
+      ! `names_to` can only be used if `values_to` is not `NULL`.
+    Code
+      (expect_error(tib_int_vec("x", input_form = "object", values_to = "val",
+        names_to = "val")))
+    Output
+      <error/rlang_error>
+      Error in `tib_int_vec()`:
+      ! `names_to` must be different from `values_to`.
+    Code
+      (expect_error(tib_int_vec("x", input_form = "object", values_to = "val",
+        names_to = 1)))
+    Output
+      <error/vctrs_error_incompatible_type>
+      Error in `tib_vector_impl()`:
+      ! Can't convert `names_to` <double> to <character>.
+    Code
+      (expect_error(tib_int_vec("x", input_form = "object", values_to = "val",
+        names_to = c("a", "b"))))
+    Output
+      <error/vctrs_error_assert_size>
+      Error in `tib_int_vec()`:
+      ! `names_to` must have size 1, not size 2.
+

--- a/tests/testthat/_snaps/tibblify.md
+++ b/tests/testthat/_snaps/tibblify.md
@@ -124,6 +124,21 @@
       Error in `stop_vector_non_list_element()`:
       ! Element at path [[1]]$x must be a list for `input_form = "object"`
 
+---
+
+    Code
+      (expect_error(tib(list(x = list(1, 1:2)), spec)))
+    Output
+      <error/rlang_error>
+      Error in `stop_vector_wrong_size_element()`:
+      ! Each element in list at path [[1]]$x must have size 1.
+    Code
+      (expect_error(tib(list(x = list(integer())), spec)))
+    Output
+      <error/rlang_error>
+      Error in `stop_vector_wrong_size_element()`:
+      ! Each element in list at path [[1]]$x must have size 1.
+
 # list column works
 
     Required element absent at path [[2]]$x

--- a/tests/testthat/_snaps/tibblify.md
+++ b/tests/testthat/_snaps/tibblify.md
@@ -109,6 +109,21 @@
 
     Can't convert <character> to <logical>.
 
+# vector column can parse scalar list
+
+    Code
+      (expect_error(tib(list(x = 1), spec)))
+    Output
+      <error/rlang_error>
+      Error in `stop_vector_non_list_element()`:
+      ! Element at path [[1]]$x must be a list for `input_form = "scalar_list"`
+    Code
+      (expect_error(tib(list(x = 1), spec_object)))
+    Output
+      <error/rlang_error>
+      Error in `stop_vector_non_list_element()`:
+      ! Element at path [[1]]$x must be a list for `input_form = "object"`
+
 # list column works
 
     Required element absent at path [[2]]$x

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -17,3 +17,10 @@ read_sample_json <- function(x) {
   path <- system.file("jsonexamples", x, package = "tibblify")
   jsonlite::fromJSON(path, simplifyDataFrame = FALSE)
 }
+
+tib <- function(x, col) {
+  tibblify(
+    list(x),
+    spec_df(x = col)
+  )
+}

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -64,7 +64,7 @@ test_that("format for tib_vector works", {
     tib_vector(
       "a",
       ptype = Sys.Date(),
-      input_form = "scalar_list",
+      input_form = "object",
       values_to = "vals",
       names_to = "names"
     ) %>%

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -59,6 +59,17 @@ test_that("format for tib_vector works", {
   local_options(cli.num_colors = 1)
   expect_snapshot(tib_chr_vec("a") %>% print())
   expect_snapshot(tib_vector("a", ptype = Sys.Date()) %>% print())
+
+  expect_snapshot(
+    tib_vector(
+      "a",
+      ptype = Sys.Date(),
+      input_form = "scalar_list",
+      values_to = "vals",
+      names_to = "names"
+    ) %>%
+      print()
+  )
 })
 
 test_that("format for tib_row works", {

--- a/tests/testthat/test-tib_spec.R
+++ b/tests/testthat/test-tib_spec.R
@@ -53,3 +53,22 @@ test_that("empty dots create empty list", {
   expect_equal(tib_df("x")$fields, list())
   expect_equal(tib_row("x")$fields, list())
 })
+
+test_that("tib_vector checks arguments", {
+  expect_snapshot({
+    (expect_error(tib_int_vec("x", input_form = "v")))
+
+    (expect_error(tib_int_vec("x", values_to = 1)))
+    (expect_error(tib_int_vec("x", values_to = c("a", "b"))))
+
+    # input_form != "object"
+    (expect_error(tib_int_vec("x", values_to = "val", names_to = "name")))
+    # values_to = NULL
+    (expect_error(tib_int_vec("x", input_form = "object", names_to = "name")))
+    # values_to = names_to
+    (expect_error(tib_int_vec("x", input_form = "object", values_to = "val", names_to = "val")))
+
+    (expect_error(tib_int_vec("x", input_form = "object", values_to = "val", names_to = 1)))
+    (expect_error(tib_int_vec("x", input_form = "object", values_to = "val", names_to = c("a", "b"))))
+  })
+})

--- a/tests/testthat/test-tibblify.R
+++ b/tests/testthat/test-tibblify.R
@@ -224,6 +224,11 @@ test_that("vector column can parse scalar list", {
     (expect_error(tib(list(x = 1), spec)))
     (expect_error(tib(list(x = 1), spec_object)))
   })
+
+  expect_snapshot({
+    (expect_error(tib(list(x = list(1, 1:2)), spec)))
+    (expect_error(tib(list(x = list(integer())), spec)))
+  })
 })
 
 test_that("vector column can parse object", {

--- a/tests/testthat/test-tibblify.R
+++ b/tests/testthat/test-tibblify.R
@@ -1,12 +1,3 @@
-tibble <- tibble::tibble
-
-tib <- function(x, col) {
-  tibblify(
-    list(x),
-    spec_df(x = col)
-  )
-}
-
 test_that("names are checked", {
   spec <- spec_object(x = tib_int("x", required = FALSE))
 

--- a/tests/testthat/test-tibblify.R
+++ b/tests/testthat/test-tibblify.R
@@ -218,8 +218,11 @@ test_that("vector column can parse scalar list", {
     tibble(x = list_of(1:2, integer()))
   )
 
+  spec_object <- spec
+  spec_object$input_form <- "object"
   expect_snapshot({
     (expect_error(tib(list(x = 1), spec)))
+    (expect_error(tib(list(x = 1), spec_object)))
   })
 })
 

--- a/tests/testthat/test-tibblify.R
+++ b/tests/testthat/test-tibblify.R
@@ -252,6 +252,20 @@ test_that("vector column creates tibble with names_to", {
     tibble(x = list_of(tibble(name = c("a", "b"), val = c(1L, NA))))
   )
 
+  # names of default value are used
+  spec2 <- tib_int_vec(
+    "x",
+    default = c(x = 1L, y = 2L),
+    required = FALSE,
+    input_form = "object",
+    values_to = "val",
+    names_to = "name"
+  )
+  expect_equal(
+    tib(list(a = 1), spec2),
+    tibble(x = list_of(tibble(name = c("x", "y"), val = c(1L, 2L))))
+  )
+
   # currently not clear what to do about missing names but it should not crash
   # and if no error is thrown it should at least produce both columns
   expect_named(

--- a/tests/testthat/test-tibblify.R
+++ b/tests/testthat/test-tibblify.R
@@ -166,13 +166,96 @@ test_that("vector column works", {
   )
 })
 
-test_that("tib_unspecified() works", {
+test_that("vector column creates tibble with values_to", {
+  spec <- tib_int_vec("x", values_to = "val")
+  expect_equal(
+    tib(list(x = 1:2), spec),
+    tibble(x = list_of(tibble(val = 1:2)))
+  )
+
+  # can handle NULL
+  expect_equal(
+    tib(list(x = NULL), spec),
+    tibble(x = list_of(NULL, .ptype = tibble(val = 1:2)))
+  )
+
+  # can handle empty vector
+  expect_equal(
+    tib(list(x = integer()), spec),
+    tibble(x = list_of(tibble(val = integer())))
+  )
+})
+
+test_that("vector column can parse scalar list", {
+  spec <- tib_int_vec("x", input_form = "scalar_list")
+  expect_equal(
+    tib(list(x = list(1, NULL, 3)), spec),
+    tibble(x = list_of(c(1L, NA, 3L)))
+  )
+
+  # handles `NULL`
   expect_equal(
     tibblify(
-      list(list(x = TRUE), list(x = 1)),
-      spec_df(x = tib_unspecified("x"))
+      list(list(x = list(1, 2)), list(x = NULL)),
+      spec_df(x = spec)
     ),
-    tibble(x = list(TRUE, 1))
+    tibble(x = list_of(1:2, NULL))
+  )
+
+  # handles empty list
+  expect_equal(
+    tibblify(
+      list(list(x = list(1, 2)), list(x = list())),
+      spec_df(x = spec)
+    ),
+    tibble(x = list_of(1:2, integer()))
+  )
+})
+
+test_that("vector column can parse object", {
+  spec <- tib_int_vec("x", input_form = "object")
+  expect_equal(
+    tib(list(x = list(a = 1, b = NULL, c = 3)), spec),
+    tibble(x = list_of(c(1L, NA, 3L)))
+  )
+
+  skip("Unclear what tib_vector should do with missing names")
+  expect_equal(
+    tib(list(x = list(1, 2)), spec),
+    tibble(x = list_of(c(1L, 2L)))
+  )
+
+  skip("Unclear what tib_vector should do with partial names")
+  expect_equal(
+    tib(list(x = list(a = 1, 2)), spec),
+    tibble(x = list_of(c(1L, 2L)))
+  )
+
+  skip("Unclear what tib_vector should do with duplicate names")
+  expect_equal(
+    tib(list(x = list(a = 1, a = 2)), spec),
+    tibble(x = list_of(c(1L, 2L)))
+  )
+})
+
+test_that("vector column creates tibble with names_to", {
+  spec <- tib_int_vec("x", input_form = "object", values_to = "val", names_to = "name")
+  expect_equal(
+    tib(list(x = list(a = 1, b = NULL)), spec),
+    tibble(x = list_of(tibble(name = c("a", "b"), val = c(1L, NA))))
+  )
+
+  # currently not clear what to do about missing names but it should not crash
+  # and if no error is thrown it should at least produce both columns
+  expect_named(
+    tib(list(x = list(1, NULL)), spec)$x[[1]],
+    c("name", "val")
+  )
+
+  skip("Unclear what tib_vector should do with missing names")
+  expect_equal(
+    tib(list(x = list(1, NULL)), spec),
+    tibble(x = list_of(tibble(name = c(NA, NA), val = c(1L, NA))))
   )
 })
 

--- a/tests/testthat/test-tibblify.R
+++ b/tests/testthat/test-tibblify.R
@@ -184,6 +184,13 @@ test_that("vector column creates tibble with values_to", {
     tib(list(x = integer()), spec),
     tibble(x = list_of(tibble(val = integer())))
   )
+
+  spec2 <- tib_int_vec("x", required = FALSE, default = c(1:2), values_to = "val")
+  # can use default
+  expect_equal(
+    tib(list(), spec2),
+    tibble(x = list_of(tibble(val = 1:2)))
+  )
 })
 
 test_that("vector column can parse scalar list", {

--- a/tests/testthat/test-tibblify.R
+++ b/tests/testthat/test-tibblify.R
@@ -217,6 +217,10 @@ test_that("vector column can parse scalar list", {
     ),
     tibble(x = list_of(1:2, integer()))
   )
+
+  expect_snapshot({
+    (expect_error(tib(list(x = 1), spec)))
+  })
 })
 
 test_that("vector column can parse object", {


### PR DESCRIPTION
Fixes #68.

This PR adds the idea of input and output form introduced in #69. Now, `tib_vector()` got three new arguments:

* `input_form`: can be "vector", "scalar_list", or "object"
* `values_to`: name of the column where the values should go. If `NULL` the output is not a tibble
* `names_to`: name of the column where the names should go.

TODOs:
* [x] Better error message for `"scalar_list"` and `"object"` if field is not a list (path + type).
* [x] Better error message for `"scalar_list"` and `"object"` if field list element has incorrect size (path + length)
* [x] Support providing named `default` and use the names