### PR TITLE
Discard `NULL` in `tspec_*(...)`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # tibblify (development version)
 
+* `tspec_*()`, `tib_df()`, and `tib_row()` now discard `NULL` in `...`. This
+  makes it easier to add a field conditionally with, for example
+  `tspec_df(if (x) tib_int("a"))`.
+
 * `tib_variant()` and `tib_vector()` give you more control for transforming:
 
   * `transform` is now applied to the whole vector.

--- a/R/tib_spec.R
+++ b/R/tib_spec.R
@@ -120,6 +120,7 @@ is_tspec <- function(x) {
 }
 
 prep_spec_fields <- function(fields, call) {
+  fields <- purrr::discard(fields, is_null)
   fields <- flatten_fields(fields)
   if (is_null(fields)) {
     return(list())

--- a/tests/testthat/test-tib_spec.R
+++ b/tests/testthat/test-tib_spec.R
@@ -31,6 +31,13 @@ test_that("can infer name from key", {
   })
 })
 
+test_that("drops NULL", {
+  expect_equal(
+    tspec_row(tib_int("a"), NULL, if (FALSE) tib_chr("b")),
+    tspec_row(tib_int("a"))
+  )
+})
+
 test_that("can nest specifications", {
   spec1 <- tspec_row(
     a = tib_int("a"),
@@ -219,6 +226,13 @@ test_that("tib_df() checks arguments", {
   expect_snapshot({
     (expect_error(tib_df("x", .names_to = 1)))
   })
+})
+
+test_that("tib_df() drops NULL", {
+  expect_equal(
+    tib_df("df", tib_int("a"), NULL, if (FALSE) tib_chr("b")),
+    tib_df("df", tib_int("a"))
+  )
 })
 
 test_that("special ptypes are not incorrectly recognized", {


### PR DESCRIPTION
To support the pattern

```r
tspec_df(
  if (x) tib_int("a")
)
```