### PR TITLE
Fix ptype of `tib_df(tib_vector())`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tibblify (development version)
 
+* Fix ptype of a `tib_vector()` inside a `tib_df()`.
+
 * New `unpack_tspec()` to unpack the elements of `tib_row()` fields (#165).
 
 * Improved printing of lists parsed with `tspec_object()`.

--- a/src/collector.c
+++ b/src/collector.c
@@ -153,7 +153,12 @@ r_obj* get_ptype_scalar(struct collector* v_collector) {
 }
 
 r_obj* get_ptype_vector(struct collector* v_collector) {
-  return v_collector->details.vec_coll.list_of_ptype;
+  r_obj* ptype = KEEP(r_alloc_list(0));
+  r_attrib_poke_class(ptype, classes_list_of);
+  r_attrib_poke(ptype, syms_ptype, v_collector->details.vec_coll.list_of_ptype);
+  FREE(1);
+
+  return ptype;
 }
 
 r_obj* get_ptype_variant(struct collector* v_collector) {

--- a/tests/testthat/test-tibblify.R
+++ b/tests/testthat/test-tibblify.R
@@ -647,7 +647,7 @@ test_that("tib_df works", {
     row = list(a = 1, b = "b"),
     df = list(list(x = 1))
   )
-  spec <- tspec_object(
+  spec <- tspec_df(
     tib_df(
       "df",
       tib_int("atomic_scalar"),
@@ -659,20 +659,22 @@ test_that("tib_df works", {
     )
   )
 
+  # This also tests whether the ptypes are calculated correctly
   expect_equal(
-    tibblify(list(df = list(x)), spec),
+    tibblify(list(list(df = list(x))), spec),
     structure(
-      list(
-        df = tibble(
-          atomic_scalar = 1L,
-          scalar = dtt,
-          vector = list_of(1:2),
-          variant = list(list(1L, "a")),
-          row = tibble(a = 1L, b = "b"),
-          df = list_of(tibble(x = 1L))
+      tibble(
+        df = list_of(
+          tibble(
+            atomic_scalar = 1L,
+            scalar = dtt,
+            vector = list_of(1:2),
+            variant = list(list(1L, "a")),
+            row = tibble(a = 1L, b = "b"),
+            df = list_of(tibble(x = 1L))
+          )
         )
-      ),
-      class = "tibblify_object"
+      )
     )
   )
 })
@@ -905,7 +907,7 @@ test_that("discog works", {
       title = "Demo",
       formats = list_of(
         tibble(
-          # descriptions = list_of("Numbered"),
+          descriptions = list_of("Numbered"),
           text         = "Black",
           name         = "Cassette",
           qty          = "1"
@@ -951,11 +953,11 @@ test_that("discog works", {
       tib_chr("title"),
       tib_df(
         "formats",
-        # tib_chr_vec(
-        #   "descriptions",
-        #   required = FALSE,
-        #   input_form = "scalar_list",
-        # ),
+        tib_chr_vec(
+          "descriptions",
+          required = FALSE,
+          input_form = "scalar_list",
+        ),
         tib_chr("text", required = FALSE),
         tib_chr("name"),
         tib_chr("qty"),
@@ -969,7 +971,10 @@ test_that("discog works", {
   )
 
   expect_equal(tibblify(discog[1], spec_collection), row1)
-  expect_equal(tibblify(row1, spec_collection), row1)
+  spec_collection2 <- spec_collection
+  spec_collection2$fields$basic_information$fields$formats$fields$descriptions <-
+    tib_chr_vec("descriptions", required = FALSE)
+  expect_equal(tibblify(row1, spec_collection2), row1)
 
   specs_object <- tspec_row(!!!spec_collection$fields)
   expect_equal(tibblify(discog[[1]], specs_object), row1)

--- a/tests/testthat/test-tibblify.R
+++ b/tests/testthat/test-tibblify.R
@@ -921,7 +921,6 @@ test_that("discog works", {
     rating = 0L
   )
 
-  # TODO think about issue with "description"
   spec_collection <- tspec_df(
     tib_int("instance_id"),
     tib_chr("date_added"),


### PR DESCRIPTION
Now uses `list_of(ptype)` instead of `ptype`