### PR TITLE
`parse_openapi_spec()` improvements

### DIFF
--- a/R/parse-open-api.R
+++ b/R/parse-open-api.R
@@ -138,7 +138,7 @@ parse_response_object <- function(response_object, openapi_spec) {
 
   out <- purrr::map(response_object$content, ~ parse_media_type_object(.x, openapi_spec))
   vctrs::new_data_frame(
-    list(media_type = names(out), spec = unname(out)),
+    list(media_type = names2(out), spec = unname(out)),
     n = length(out)
   )
 }

--- a/R/parse-open-api.R
+++ b/R/parse-open-api.R
@@ -98,7 +98,9 @@ parse_openapi_schema <- function(file) {
 
 read_spec <- function(file, arg = caller_arg(file), call = caller_env()) {
   rlang::check_installed("yaml")
-  if (is_character(file)) {
+  if (is_list(file)) {
+    file
+  } else if (is_character(file)) {
     check_string(file)
 
     if (grepl("\n", file)) {

--- a/R/parse-open-api.R
+++ b/R/parse-open-api.R
@@ -127,14 +127,14 @@ parse_path_object <- function(path_object, openapi_spec) {
 }
 
 parse_operation_object <- function(operation_object, openapi_spec) {
-  operation_object <- openapi_get_schema(operation_object, openapi_spec)
+  operation_object <- openapi_resolve_schema(operation_object, openapi_spec)
 
   out <- purrr::map(operation_object$responses, ~ parse_response_object(.x, openapi_spec))
   vctrs::vec_rbind(!!!out, .names_to = "status_code")
 }
 
 parse_response_object <- function(response_object, openapi_spec) {
-  response_object <- openapi_get_schema(response_object, openapi_spec)
+  response_object <- openapi_resolve_schema(response_object, openapi_spec)
 
   out <- purrr::map(response_object$content, ~ parse_media_type_object(.x, openapi_spec))
   vctrs::new_data_frame(
@@ -148,7 +148,7 @@ parse_media_type_object <- function(media_type_object, openapi_spec) {
 }
 
 schema_to_tspec <- function(schema, openapi_spec) {
-  schema <- openapi_get_schema(schema, openapi_spec)
+  schema <- openapi_resolve_schema(schema, openapi_spec)
 
   if (!is.null(schema$oneOf)) {
     out <- handle_one_of_tspec(schema, openapi_spec)
@@ -166,7 +166,7 @@ schema_to_tspec <- function(schema, openapi_spec) {
 
     tspec_row(!!!fields)
   } else if (type == "array") {
-    schema <- openapi_get_schema(schema$items, openapi_spec)
+    schema <- openapi_resolve_schema(schema$items, openapi_spec)
 
     fields <- purrr::imap(schema$properties, ~ parse_schema_memoised(.x, .y, openapi_spec))
     fields <- apply_required(fields, schema$required)
@@ -189,7 +189,7 @@ apply_required <- function(fields, required) {
   fields
 }
 
-openapi_get_schema <- function(schema, openapi_spec) {
+openapi_resolve_schema <- function(schema, openapi_spec) {
   ref <- schema$`$ref`
   # FIXME this is probably quite a hack...
   ref <- ref %||% schema$allOf[[1]]$`$ref`
@@ -198,18 +198,15 @@ openapi_get_schema <- function(schema, openapi_spec) {
     if (ref_parts[[1]] != "#") {
       cli_abort("{.field ref} does not start with {.value #}", .internal = TRUE)
     }
-    # TODO better error message
-    tryCatch({
-      schema <- purrr::chuck(openapi_spec, !!!ref_parts[-1])
-    }, error = function(cnd) {
-      browser()
-    }
-    )
     schema <- purrr::chuck(openapi_spec, !!!ref_parts[-1])
+
+    if (is.null(schema)) {
+      cli_abort("No schema found for reference {.value {ref}}")
+    }
   }
 
-  if (is.null(schema)) {
-    cli_abort("No schema found for reference {.value {ref}}")
+  if (has_name(schema, "$ref")) {
+    schema <- openapi_resolve_schema(schema, openapi_spec)
   }
 
   # TODO check schema?
@@ -231,7 +228,7 @@ get_openapi_type <- function(schema) {
 }
 
 parse_schema <- function(schema, name, openapi_spec) {
-  schema <- openapi_get_schema(schema, openapi_spec)
+  schema <- openapi_resolve_schema(schema, openapi_spec)
   if (!is.null(schema$oneOf)) {
     out <- handle_one_of(schema, name, openapi_spec)
     return(out)
@@ -249,7 +246,7 @@ parse_schema <- function(schema, name, openapi_spec) {
   if (is_empty(type)) {
   } else if (type == "object") {
     if (!is.null(schema$additionalProperties)) {
-      additional_properties <- openapi_get_schema(schema$additionalProperties, openapi_spec)
+      additional_properties <- openapi_resolve_schema(schema$additionalProperties, openapi_spec)
     } else {
       additional_properties <- NULL
     }

--- a/R/shape_utils.R
+++ b/R/shape_utils.R
@@ -54,7 +54,7 @@ should_guess_object_list <- function(x) {
 }
 
 get_overview <- function(x) {
-  classes <- purrr::map_chr(x, ~ class(.x)[1])
+  classes <- compat_map_chr(x, ~ class(.x)[1])
   paste0("  ", names(classes), ": ", classes, collapse = "\n")
 }
 
@@ -136,7 +136,7 @@ choose_type <- function(x, arg) {
   }
 
   # TODO nicer overview
-  overviews <- purrr::map_chr(x, get_overview)
+  overviews <- compat_map_chr(x, get_overview)
   x_overview <- paste0(names(x), "\n", overviews, collapse = "\n")
 
   msg <- c(

--- a/R/spec_combine.R
+++ b/R/spec_combine.R
@@ -64,7 +64,7 @@ check_tspec_combine_dots <- function(..., .call = caller_env()) {
 }
 
 check_tspec_combine_type <- function(spec_list, call = caller_env()) {
-  types <- purrr::map_chr(spec_list, "type")
+  types <- compat_map_chr(spec_list, "type")
   type_locs <- vec_unique_loc(types)
 
   if (length(type_locs) > 1) {
@@ -149,7 +149,7 @@ tib_combine <- function(tib_list, name, call) {
 }
 
 tib_combine_type <- function(tib_list, call) {
-  types <- purrr::map_chr(tib_list, "type")
+  types <- compat_map_chr(tib_list, "type")
   locs <- vec_unique_loc(types)
   types <- types[locs]
   unspecified_idx <- types == "unspecified"
@@ -221,7 +221,7 @@ tib_combine_ptype <- function(tib_list, call) {
 }
 
 tib_combine_fill <- function(tib_list, type, ptype, call) {
-  types <- purrr::map_chr(tib_list, "type")
+  types <- compat_map_chr(tib_list, "type")
   unspecified_locs <- which(types == "unspecified")
 
   fill_list <- lapply(tib_list, `[[`, "fill")
@@ -238,7 +238,7 @@ tib_combine_fill <- function(tib_list, type, ptype, call) {
 
     if (length(fill_locs2) > 1) {
       # TODO better error message
-      values <- purrr::map_chr(fill_list_cast, as_label)
+      values <- compat_map_chr(fill_list_cast, as_label)
       value_infos <- loc_name_helper(fill_locs2, values)
       cli::cli_abort("Can't combine fill {value_infos}", call = call)
     }
@@ -281,12 +281,12 @@ tib_combine_transform <- function(tib_list, call) {
 }
 
 tib_combine_input_form <- function(tib_list, call) {
-  types <- purrr::map_chr(tib_list, "type")
+  types <- compat_map_chr(tib_list, "type")
   if (any(types != "vector")) {
     tib_list <- tib_list[types == "vector"]
   }
 
-  input_forms <- purrr::map_chr(tib_list, "input_form")
+  input_forms <- compat_map_chr(tib_list, "input_form")
   input_form_locs <- vec_unique_loc(input_forms)
 
   if (length(input_form_locs) > 1) {
@@ -304,7 +304,7 @@ tib_combine_input_form <- function(tib_list, call) {
 }
 
 tib_combine_names_col <- function(tib_list, call) {
-  names_col <- purrr::map_chr(tib_list, "names_col", .default = NA)
+  names_col <- compat_map_chr(tib_list, "names_col", .default = NA)
   names_col_locs <- vec_unique_loc(names_col)
   na_locs <- which(vec_detect_missing(names_col))
 

--- a/R/spec_combine.R
+++ b/R/spec_combine.R
@@ -77,7 +77,7 @@ check_tspec_combine_type <- function(spec_list, call = caller_env()) {
 tspec_combine_field_list <- function(spec_list, call) {
   fields_list <- purrr::map(spec_list, "fields")
   empty_idx <- lengths(fields_list) == 0
-  nms_list <- purrr::map(fields_list, names)
+  nms_list <- purrr::map(fields_list, function(x) names(x))
   nms <- vec_unique(vec_flatten(nms_list, character()))
   fields_list_t <- purrr::list_transpose(fields_list[!empty_idx], template = nms)
 
@@ -191,7 +191,7 @@ tib_combine_key <- function(tib_list, name, call) {
 }
 
 tib_combine_required <- function(tib_list) {
-  null_idx <- purrr::detect_index(tib_list, is_null)
+  null_idx <- purrr::detect_index(tib_list, function(x) is_null(x))
   if (null_idx != 0) {
     return(FALSE)
   }

--- a/R/tib_spec.R
+++ b/R/tib_spec.R
@@ -180,7 +180,7 @@ spec_auto_name_fields <- function(fields, error_call) {
   field_nms <- names2(fields)
   unnamed <- !have_name(fields)
   auto_nms <- with_indexed_errors(
-    purrr::map_chr(
+    compat_map_chr(
       fields[unnamed],
       function(field) {
         key <- field$key

--- a/R/tibblify.R
+++ b/R/tibblify.R
@@ -173,7 +173,7 @@ spec_prep <- function(spec) {
   if (type == "recursive") {
     spec$type <- "df"
     spec["names_col"] <- list(NULL)
-    spec$child_coll_pos <- which(purrr::map_chr(spec$fields, "type") == "recursive_helper") - 1L
+    spec$child_coll_pos <- which(compat_map_chr(spec$fields, "type") == "recursive_helper") - 1L
   }
 
   spec
@@ -247,7 +247,7 @@ prep_nested_keys2 <- function(spec, coll_locations) {
     vec_split(coll_locations[is_sub], first_keys[is_sub])$val
   )
 
-  first_keys <- purrr::map_chr(spec_out, list("key", 1))
+  first_keys <- compat_map_chr(spec_out, list("key", 1))
   key_order <- order(first_keys)
 
   list(

--- a/R/unnest-tree.R
+++ b/R/unnest-tree.R
@@ -96,7 +96,7 @@ unnest_tree <- function(data,
 
     if (!is_null(ancestors_to)) {
       if (level > 1L) {
-        ancestors_simple <- purrr::map2(cur_ancestors, vctrs::vec_chop(parent_ids), c)
+        ancestors_simple <- purrr::map2(cur_ancestors, vctrs::vec_chop(parent_ids), function(x, y) c(x, y))
         cur_ancestors <- vctrs::vec_rep_each(ancestors_simple, ns)
       }
       level_ancestors[[level]] <- cur_ancestors

--- a/R/utils.R
+++ b/R/utils.R
@@ -201,8 +201,7 @@ list_drop_null <- function(x) {
 }
 
 compat_map_chr <- function(x, .f, ...) {
-  out <- purrr::map(x, .f, ...)
-  vctrs::list_unchop(out, ptype = character())
+  purrr::map_vec(x, .f, ..., .ptype = character())
 }
 
 with_indexed_errors <- function(expr,

--- a/R/utils.R
+++ b/R/utils.R
@@ -46,7 +46,7 @@ path_to_string <- function(path) {
     return("x")
   }
 
-  path_elements <- purrr::map_chr(
+  path_elements <- compat_map_chr(
     path_elts[1:depth],
     function(elt) {
       if (is.character(elt)) {
@@ -198,6 +198,11 @@ list_drop_null <- function(x) {
   }
 
   x
+}
+
+compat_map_chr <- function(x, .f, ...) {
+  out <- purrr::map(x, .f, ...)
+  vctrs::list_unchop(out, ptype = character())
 }
 
 with_indexed_errors <- function(expr,


### PR DESCRIPTION
Fixes #186.

Now the three specs that failed all work:

```r
asana_yaml <- yaml::read_yaml("https://raw.githubusercontent.com/Asana/openapi/master/defs/asana_oas.yaml", handlers = list(int = as.character))
asana_spec <- parse_openapi_spec(asana_yaml)

zoom_yaml <- yaml::read_yaml("https://api.apis.guru/v2/specs/zoom.us/2.0.0/openapi.yaml", handlers = list(int = as.character))
zoom_spec <- parse_openapi_spec(zoom_yaml)

youtube_yaml <- yaml::read_yaml("https://api.apis.guru/v2/specs/googleapis.com/youtube/v3/openapi.yaml")
youtube_spec <- parse_openapi_spec(youtube_yaml)
```

~While this can now be parsed, the performance could be improved.~ After some minor changes the performance is quite okay.