### PR TITLE
parse_openapi_spec() for more URLs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tibblify
 Title: Rectangle Nested Lists
-Version: 0.3.0.9000
+Version: 0.3.1.9000
 Authors@R: c(
     person("Maximilian", "Girlich", , "maximilian.girlich@outlook.com", role = c("aut", "cre", "cph")),
     person("Kirill", "Müller", role = "ctb")
@@ -16,16 +16,16 @@ URL: https://github.com/mgirlich/tibblify,
     https://mgirlich.github.io/tibblify/
 BugReports: https://github.com/mgirlich/tibblify/issues
 Depends: 
-    R (>= 3.4.0)
+    R (>= 3.6.0)
 Imports: 
-    cli (>= 3.3.0),
-    lifecycle (>= 1.0.1),
-    purrr (>= 1.0.1),
-    rlang (>= 1.1.0),
-    tibble (>= 3.1.8),
+    cli (>= 3.6.2),
+    lifecycle (>= 1.0.4),
+    purrr (>= 1.0.2),
+    rlang (>= 1.1.3),
+    tibble (>= 3.2.1),
     tidyselect (>= 1.2.0),
-    vctrs (>= 0.5.0),
-    withr (>= 2.5.0)
+    vctrs (>= 0.6.5),
+    withr (>= 2.5.2)
 Suggests: 
     covr (>= 3.6.1),
     jsonlite (>= 1.8.0),
@@ -36,7 +36,7 @@ Suggests:
     testthat (>= 3.1.4),
     yaml (>= 2.3.6)
 LinkingTo: 
-    vctrs (>= 0.5.0)
+    vctrs (>= 0.6.5)
 VignetteBuilder: 
     knitr
 Config/testthat/edition: 3
@@ -45,5 +45,4 @@ Language: en-US
 LazyData: true
 NeedsCompilation: yes
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.2
-SystemRequirements: C++11
+RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,4 +45,4 @@ Language: en-US
 LazyData: true
 NeedsCompilation: yes
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tibblify (development version)
 
+# tibblify 0.3.1
+
 * New `parse_openapi_spec()` and `parse_openapi_schema()` to convert an
   OpenAPI specification to a tibblify specification.
 
@@ -8,6 +10,10 @@
 * New `unpack_tspec()` to unpack the elements of `tib_row()` fields (#165).
 
 * Improved printing of lists parsed with `tspec_object()`.
+
+* Improved performance of the `tspec()` family.
+
+* Improved guessing.
 
 # tibblify 0.3.0
 

--- a/R/parse-open-api.R
+++ b/R/parse-open-api.R
@@ -30,11 +30,11 @@
 #'   "properties": {
 #'     "name": {
 #'       "type": "string",
-#'       "description": "The name of this vehicle. The common name, such as Sand Crawler."
+#'       "description": "The name of this vehicle. The common name, e.g. Sand Crawler."
 #'     },
 #'     "model": {
 #'       "type": "string",
-#'       "description": "The model or official name of this vehicle. Such as All Terrain Attack Transport."
+#'       "description": "The model or official name of this vehicle."
 #'     },
 #'     "url": {
 #'       "type": "string",
@@ -44,7 +44,7 @@
 #'     "edited": {
 #'       "type": "string",
 #'       "format": "date-time",
-#'       "description": "the ISO 8601 date format of the time that this resource was edited."
+#'       "description": "the ISO 8601 date format of the time this resource was edited."
 #'     }
 #'   },
 #'   "required": [

--- a/R/parse-open-api.R
+++ b/R/parse-open-api.R
@@ -182,6 +182,7 @@ parse_operation_object <- function(operation_object, openapi_spec) {
   data$request_body <- list(parse_request_body(data$request_body, openapi_spec))
   data$parameters <- list(parse_parameters(data$parameters, openapi_spec))
   data$responses <- list(parse_responses_object(data$responses, openapi_spec))
+  data$tags <- list(data$tags)
 
   fast_tibble(unclass(data), n = 1L)
 }

--- a/R/parse-open-api.R
+++ b/R/parse-open-api.R
@@ -249,7 +249,7 @@ parse_responses_object <- function(responses_object, openapi_spec) {
 
 parse_response_object <- function(response_object, openapi_spec) {
   spec <- tspec_object(
-    tib_chr("description"),
+    tib_chr("description", required = FALSE),
     tib_variant("headers", required = FALSE),
     tib_variant("content", required = FALSE),
     tib_variant("links", required = FALSE),
@@ -363,6 +363,10 @@ openapi_resolve_reference <- function(schema, openapi_spec) {
   # FIXME this is probably quite a hack...
   ref <- ref %||% schema$allOf[[1]]$`$ref`
   if (!is.null(ref)) {
+    if (is_url_string(ref)) {
+      other_parts <- schema[setdiff(names(schema), "$ref")]
+      return(c(yaml::read_yaml(ref, readLines.warn = FALSE), other_parts))
+    }
     ref_parts <- strsplit(ref, "/")[[1]]
     if (ref_parts[[1]] != "#") {
       cli_abort("{.field ref} does not start with {.value #}", .internal = TRUE)

--- a/R/shape_utils.R
+++ b/R/shape_utils.R
@@ -147,6 +147,6 @@ choose_type <- function(x, arg) {
   inform(x_overview)
 
   title <- cli::format_message("How do you want to parse {.arg {arg}}?")
-  choice <- menu(c("object", "object list"), title = title)
+  choice <- utils::menu(c("object", "object list"), title = title)
   return(choice)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -216,3 +216,7 @@ with_indexed_errors <- function(expr,
     }
   )
 }
+
+is_url_string <- function(x, arg = caller_arg(x), call = caller_env()) {
+  rlang::is_scalar_character(x) && grepl("^https?://", x)
+}

--- a/README.md
+++ b/README.md
@@ -71,13 +71,12 @@ tibblify(gh_users_small)
 #> The spec contains 1 unspecified field:
 #> • email
 #> # A tibble: 4 × 7
-#>   followers login      url                          name  locat…¹ email  publi…²
-#>       <int> <chr>      <chr>                        <chr> <chr>   <list>   <int>
-#> 1       780 jennybc    https://api.github.com/user… Jenn… Vancou… <NULL>      54
-#> 2      3958 jtleek     https://api.github.com/user… Jeff… Baltim… <NULL>      12
-#> 3       115 juliasilge https://api.github.com/user… Juli… Salt L… <NULL>       4
-#> 4       213 leeper     https://api.github.com/user… Thom… London… <NULL>      46
-#> # … with abbreviated variable names ¹​location, ²​public_gists
+#>   followers login      url                    name  location email  public_gists
+#>       <int> <chr>      <chr>                  <chr> <chr>    <list>        <int>
+#> 1       780 jennybc    https://api.github.co… Jenn… Vancouv… <NULL>           54
+#> 2      3958 jtleek     https://api.github.co… Jeff… Baltimo… <NULL>           12
+#> 3       115 juliasilge https://api.github.co… Juli… Salt La… <NULL>            4
+#> 4       213 leeper     https://api.github.co… Thom… London,… <NULL>           46
 ```
 
 We can now look at the specification `tibblify()` used for rectangling
@@ -342,7 +341,7 @@ tibblify(gh_repos_small, spec)
 #>  8 67959624 cmark       gaborcsardi 660288 https://api.github.com/users/gaborcs…
 #>  9 63152619 conditions  gaborcsardi 660288 https://api.github.com/users/gaborcs…
 #> 10 24343686 crayon      gaborcsardi 660288 https://api.github.com/users/gaborcs…
-#> # … with 20 more rows
+#> # ℹ 20 more rows
 ```
 
 If you don’t like the tibble column you can unpack it with
@@ -378,7 +377,7 @@ tibblify(gh_repos_small, spec2)
 #>  8 67959624 cmark         660288 gaborcsardi
 #>  9 63152619 conditions    660288 gaborcsardi
 #> 10 24343686 crayon        660288 gaborcsardi
-#> # … with 20 more rows
+#> # ℹ 20 more rows
 ```
 
 ## Required and Optional Fields

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,9 +2,5 @@
 
 0 errors | 0 warnings | 1 note
 
-* This is a new release.
-* This is a resubmission:
-  * added documentation for return values of `get_spec()`, `lcol_lgl()` and `lcols()`.
-* The package was archived due to containing marked UTF-8 strings. These strings
-  were removed for this release.
+* This fixes the C issue: format string is not a string literal.
   

--- a/man/parse_openapi_spec.Rd
+++ b/man/parse_openapi_spec.Rd
@@ -41,11 +41,11 @@ file <- '{
   "properties": {
     "name": {
       "type": "string",
-      "description": "The name of this vehicle. The common name, such as Sand Crawler."
+      "description": "The name of this vehicle. The common name, e.g. Sand Crawler."
     },
     "model": {
       "type": "string",
-      "description": "The model or official name of this vehicle. Such as All Terrain Attack Transport."
+      "description": "The model or official name of this vehicle."
     },
     "url": {
       "type": "string",
@@ -55,7 +55,7 @@ file <- '{
     "edited": {
       "type": "string",
       "format": "date-time",
-      "description": "the ISO 8601 date format of the time that this resource was edited."
+      "description": "the ISO 8601 date format of the time this resource was edited."
     }
   },
   "required": [

--- a/man/tibblify-package.Rd
+++ b/man/tibblify-package.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{tibblify-package}
 \alias{tibblify-package}
-\alias{_PACKAGE}
 \title{tibblify: Rectangle Nested Lists}
 \description{
 A tool to rectangle a nested list, that is to convert it into a tibble. This is done automatically or according to a given specification. A common use case is for nested lists coming from parsing JSON files or the JSON response of REST APIs. It is supported by the 'vctrs' package and therefore offers a wide support of vector types.

--- a/src/decl/vctrs-utils-dispatch-decl.h
+++ b/src/decl/vctrs-utils-dispatch-decl.h
@@ -2,6 +2,3 @@ enum vctrs_class_type class_type(r_obj* x);
 
 static
 enum vctrs_class_type class_type_impl(r_obj* cls);
-
-static
-const char* class_type_as_str(enum vctrs_class_type type);

--- a/src/parse-spec.c
+++ b/src/parse-spec.c
@@ -128,8 +128,8 @@ struct collector* parse_spec_elt(r_obj* spec_elt,
                                 r_list_get_by_name(spec_elt, "list_of_ptype"),
                                 rowmajor);
   } else {
-    r_printf(CHAR(type)); // # nocov
-    r_printf(CHAR(r_string_types.scalar)); // # nocov
+    r_printf("%s", CHAR(type)); // # nocov
+    r_printf("%s", CHAR(r_string_types.scalar)); // # nocov
     r_stop_internal("Internal Error: Unsupported type"); // # nocov
   }
 }

--- a/src/vctrs-utils-dispatch.c
+++ b/src/vctrs-utils-dispatch.c
@@ -84,22 +84,3 @@ enum vctrs_class_type class_type_impl(r_obj* cls) {
 
   return VCTRS_CLASS_unknown;
 }
-
-static
-const char* class_type_as_str(enum vctrs_class_type type) {
-  switch (type) {
-  case VCTRS_CLASS_list: return "list";
-  case VCTRS_CLASS_data_frame: return "data_frame";
-  case VCTRS_CLASS_bare_asis: return "bare_asis";
-  case VCTRS_CLASS_bare_data_frame: return "bare_data_frame";
-  case VCTRS_CLASS_bare_tibble: return "bare_tibble";
-  case VCTRS_CLASS_bare_factor: return "bare_factor";
-  case VCTRS_CLASS_bare_ordered: return "bare_ordered";
-  case VCTRS_CLASS_bare_date: return "bare_date";
-  case VCTRS_CLASS_bare_posixct: return "bare_posixct";
-  case VCTRS_CLASS_bare_posixlt: return "bare_posixlt";
-  case VCTRS_CLASS_unknown: return "unknown";
-  case VCTRS_CLASS_none: return "none";
-  }
-  never_reached("class_type_as_str");
-}

--- a/tests/testthat/_snaps/nest-tree.md
+++ b/tests/testthat/_snaps/nest-tree.md
@@ -11,7 +11,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `eval_pull()`:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `not-there` doesn't exist.
     Code
       (expect_error(nest_tree(df, 1:2)))
@@ -24,7 +24,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `eval_pull()`:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `not-there` doesn't exist.
     Code
       (expect_error(nest_tree(df, id, parent_col = 1:2)))

--- a/tests/testthat/_snaps/unnest-tree.md
+++ b/tests/testthat/_snaps/unnest-tree.md
@@ -11,7 +11,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `eval_pull()`:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `not-there` doesn't exist.
     Code
       (expect_error(unnest_tree(df, id_col = 1:2)))
@@ -105,13 +105,6 @@
       <error/vctrs_error_assert_size>
       Error in `unnest_tree()`:
       ! `ancestors_to` must have size 1, not size 2.
-
----
-
-    Code
-      NULL
-    Output
-      NULL
 
 # child col type is checked
 

--- a/tests/testthat/test-parse-open-api.R
+++ b/tests/testthat/test-parse-open-api.R
@@ -2,9 +2,14 @@ test_that("can parse open api spec", {
   skip_on_cran()
   skip_if(getRversion() < "3.6")
   expect_no_error(
-    # supprss `incomplete final line` warning
+    # suppress `incomplete final line` warning
     suppressWarnings(
       parse_openapi_spec("https://dtrnk0o2zy01c.cloudfront.net/openapi/en-us/dest/SponsoredProducts_prod_3p.json")
     )
   )
+
+  # TODO: More tests! Some URLs that previously failed:
+  # * "https://api.apis.guru/v2/specs/slack.com/1.7.0/openapi.json"
+  # * "https://api.apis.guru/v2/specs/sportsdata.io/csgo-v3-scores/1.0/openapi.json"
+  # * "https://mapineqfeatures.web.rug.nl/api.json"
 })

--- a/tests/testthat/test-unnest-tree.R
+++ b/tests/testthat/test-unnest-tree.R
@@ -30,10 +30,6 @@ test_that("checks arguments", {
     (expect_error(unnest_tree(df, id, children, ancestors_to = "id")))
     (expect_error(unnest_tree(df, id, children, ancestors_to = c("a", "b"))))
   })
-
-  expect_snapshot({
-
-  })
 })
 
 test_that("child col type is checked", {


### PR DESCRIPTION
- Listified tags. This was causing a lot of specs to fail. I suspect this can be cleaner with tib_variant but I wanted to get it functional before refactoring.
- If a spec `$ref`s a URL, import that rather than finding the ref in other parts of the spec. May need refinement but it seems to work for the case I've seen (https://mapineqfeatures.web.rug.nl/api.json)
- Make the `description` field of a response object optional.

I also merged in main, fixed a couple issues with the build, and redocumented.