### PR TITLE
Fix for upcoming testthat 3.3.0 release

### DIFF
--- a/tests/testthat/_snaps/nest-tree.md
+++ b/tests/testthat/_snaps/nest-tree.md
@@ -11,7 +11,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `eval_pull()`:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `not-there` doesn't exist.
     Code
       (expect_error(nest_tree(df, 1:2)))
@@ -24,7 +24,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `eval_pull()`:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `not-there` doesn't exist.
     Code
       (expect_error(nest_tree(df, id, parent_col = 1:2)))

--- a/tests/testthat/_snaps/unnest-tree.md
+++ b/tests/testthat/_snaps/unnest-tree.md
@@ -11,7 +11,7 @@
     Output
       <error/vctrs_error_subscript_oob>
       Error in `eval_pull()`:
-      ! Can't subset columns that don't exist.
+      ! Can't select columns that don't exist.
       x Column `not-there` doesn't exist.
     Code
       (expect_error(unnest_tree(df, id_col = 1:2)))
@@ -105,13 +105,6 @@
       <error/vctrs_error_assert_size>
       Error in `unnest_tree()`:
       ! `ancestors_to` must have size 1, not size 2.
-
----
-
-    Code
-      NULL
-    Output
-      NULL
 
 # child col type is checked
 

--- a/tests/testthat/test-unnest-tree.R
+++ b/tests/testthat/test-unnest-tree.R
@@ -30,10 +30,6 @@ test_that("checks arguments", {
     (expect_error(unnest_tree(df, id, children, ancestors_to = "id")))
     (expect_error(unnest_tree(df, id, children, ancestors_to = c("a", "b"))))
   })
-
-  expect_snapshot({
-
-  })
 })
 
 test_that("child col type is checked", {


### PR DESCRIPTION
`expect_snasphot({})` now errors. I also updated the snapshots.